### PR TITLE
Add grouping, etc

### DIFF
--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -1,0 +1,15 @@
+on: [push, pull_request]
+name: Clippy check
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 name: Clippy check
 jobs:
   clippy_check:

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,0 +1,79 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+#
+# While our "example" application has the platform-specific code,
+# for simplicity we are compiling and testing everything on the Ubuntu environment only.
+# For multi-OS testing see the `cross.yml` workflow.
+
+on: [push, pull_request]
+
+name: Quickstart
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: test
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 Cargo.lock
 target
-
+schemas

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "yaml.schemas": {
+        "./schemas/style.json": ["/*.csl.yaml"],
+        "./schemas/bibliography.json": ["/*.bib.yaml"]
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,5 +17,6 @@ fn main() {
     let bibliography_path: &String = &args[2];
     let bibliography: Bibliography = load_bibliography_from_file(bibliography_path);
     let processor: Processor = Processor::new(style, bibliography, bibliography_path.to_string());
-    println!("{:?}", processor.get_proc_references());
+    let prefs = processor.get_proc_references();
+    println!("{:?}", processor.group_proc_references(prefs));
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,5 +18,5 @@ fn main() {
     let bibliography: Bibliography = load_bibliography_from_file(bibliography_path);
     let processor: Processor = Processor::new(style, bibliography, bibliography_path.to_string());
     let prefs = processor.get_proc_references();
-    println!("{:?}", processor.group_proc_references(prefs));
+    println!("{:?}", prefs);
 }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -22,3 +22,4 @@ edtf = "0.2.0"
 chrono = { version = "0.4", features = ["unstable-locales"] }
 style = { path = "../style", package = "csln-style" }
 bibliography = { path = "../bibliography", package = "csln-bibliography" }
+itertools = "0.10.5"

--- a/processor/examples/ex1.bib.yaml
+++ b/processor/examples/ex1.bib.yaml
@@ -1,27 +1,27 @@
 ---
 un:
   type: article
-  title: E Title
+  title: Title 4
   author: ["United Nations"]
   issued: '2020'
 smith1:
   type: book
-  title: B Title
+  title: Title 3
   author: ["Smith, Sam"]
   issued: '2023-10'
 doe1:
   type: book
-  title: A Title
+  title: Title 2
   author: ["Doe, Jane"]
   issued: '2023-10'
 doe2:
   type: book
-  title: C Title
+  title: Title 1
   author: ["Doe, Jane"]
   issued: '2023'
 doe3:
   type: article
-  title: D Title
+  title: Title 0
   author: ["Doe, Jane"]
   issued: '2020'
 

--- a/processor/examples/ex1.bib.yaml
+++ b/processor/examples/ex1.bib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../schemas/bibliography.json
 ---
 un:
   type: article

--- a/processor/examples/ex1.bib.yaml
+++ b/processor/examples/ex1.bib.yaml
@@ -18,7 +18,7 @@ doe2:
   type: book
   title: Title 1
   author: ["Doe, Jane"]
-  issued: '2023'
+  issued: '2020'
 doe3:
   type: article
   title: Title 0

--- a/processor/examples/style.csl.yaml
+++ b/processor/examples/style.csl.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../schemas/style.json
 ---
 info:
   title: APA

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -1,8 +1,8 @@
-use std::fs;
 use chrono::NaiveDate;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use std::fs;
 use std::option::Option;
 
 use bibliography::InputBibliography as Bibliography;
@@ -24,43 +24,25 @@ The primary target is a JSON AST, represented by the ProcTemplate struct.
  */
 
 pub fn load_style_from_file(style_path: &str) -> Style {
+    let contents = fs::read_to_string(style_path).expect("Failed to read style file");
     if style_path.ends_with(".json") {
-        load_style_from_json(style_path)
+        serde_json::from_str(&contents).expect("Failed to parse JSON")
     } else if style_path.ends_with(".yaml") || style_path.ends_with(".yml") {
-        load_style_from_yaml(style_path)
+        serde_yaml::from_str(&contents).expect("Failed to parse YAML")
     } else {
         panic!("Style file must be in YAML or JSON format")
     }
-}
-
-fn load_style_from_yaml(style_path: &str) -> Style {
-    let contents = fs::read_to_string(style_path).expect("Failed to read style file");
-    serde_yaml::from_str(&contents).expect("Failed to parse YAML")
-}
-
-fn load_style_from_json(style_path: &str) -> Style {
-    let contents = fs::read_to_string(style_path).expect("Failed to read style file");
-    serde_json::from_str(&contents).expect("Failed to parse JSON")
 }
 
 pub fn load_bibliography_from_file(bib_path: &str) -> Bibliography {
+    let contents = fs::read_to_string(bib_path).expect("Failed to read bibliography file");
     if bib_path.ends_with(".json") {
-        load_bib_from_json(bib_path)
+        serde_json::from_str(&contents).expect("Failed to parse JSON")
     } else if bib_path.ends_with(".yaml") || bib_path.ends_with(".yml") {
-        load_bib_from_yaml(bib_path)
+        serde_yaml::from_str(&contents).expect("Failed to parse YAML")
     } else {
         panic!("Style file must be in YAML or JSON format")
     }
-}
-
-fn load_bib_from_yaml(bib_path: &str) -> Bibliography {
-    let contents = fs::read_to_string(bib_path).expect("Failed to read style file");
-    serde_yaml::from_str(&contents).expect("Failed to parse YAML")
-}
-
-fn load_bib_from_json(bib_path: &str) -> Bibliography {
-    let contents = fs::read_to_string(bib_path).expect("Failed to read style file");
-    serde_json::from_str(&contents).expect("Failed to parse JSON")
 }
 
 /// The processor struct, which takes a style, a bibliography, and a locale, and renders the output.

--- a/processor/tests/processor_test.rs
+++ b/processor/tests/processor_test.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn test_get_proc_references() {
         let style = load_style_from_file("examples/style.csl.yaml");
-        let bibliography = load_bibliography_from_file("examples/bibliography.yaml");
+        let bibliography = load_bibliography_from_file("examples/ex1.bib.yaml");
         let processor = csln_processor::Processor::new(style, bibliography, "en-US".to_string());
         let proc_references = processor.get_proc_references();
         assert_eq!(proc_references.len(), 5);

--- a/processor/tests/processor_test.rs
+++ b/processor/tests/processor_test.rs
@@ -1,76 +1,6 @@
-#[test]
-fn test_group_proc_references() {
-    let processor = Processor::new(Bibliography::default(), Style::default());
-    let proc_references = processor.get_proc_references();
-    let grouped_proc_references = processor.group_proc_references(proc_references);
-    assert_eq!(grouped_proc_references.len(), 4);
-    assert_eq!(
-        grouped_proc_references[0].proc_hints.as_ref().unwrap().group_key,
-        "Doe2020"
-    );
-    assert_eq!(
-        grouped_proc_references[0].proc_hints.as_ref().unwrap().group_index,
-        0
-    );
-    assert_eq!(
-        grouped_proc_references[0].proc_hints.as_ref().unwrap().group_length,
-        2
-    );
-    assert_eq!(
-        grouped_proc_references[0].proc_hints.as_ref().unwrap().disamb_condition,
-        false
-    );
-    assert_eq!(
-        grouped_proc_references[1].proc_hints.as_ref().unwrap().group_key,
-        "Doe2021"
-    );
-    assert_eq!(
-        grouped_proc_references[1].proc_hints.as_ref().unwrap().group_index,
-        1
-    );
-    assert_eq!(
-        grouped_proc_references[1].proc_hints.as_ref().unwrap().group_length,
-        1
-    );
-    assert_eq!(
-        grouped_proc_references[1].proc_hints.as_ref().unwrap().disamb_condition,
-        false
-    );
-    assert_eq!(
-        grouped_proc_references[2].proc_hints.as_ref().unwrap().group_key,
-        "Smith2020"
-    );
-    assert_eq!(
-        grouped_proc_references[2].proc_hints.as_ref().unwrap().group_index,
-        2
-    );
-    assert_eq!(
-        grouped_proc_references[2].proc_hints.as_ref().unwrap().group_length,
-        1
-    );
-    assert_eq!(
-        grouped_proc_references[2].proc_hints.as_ref().unwrap().disamb_condition,
-        false
-    );
-    assert_eq!(
-        grouped_proc_references[3].proc_hints.as_ref().unwrap().group_key,
-        "Smith2021"
-    );
-    assert_eq!(
-        grouped_proc_references[3].proc_hints.as_ref().unwrap().group_index,
-        3
-    );
-    assert_eq!(
-        grouped_proc_references[3].proc_hints.as_ref().unwrap().group_length,
-        1
-    );
-    assert_eq!(
-        grouped_proc_references[3].proc_hints.as_ref().unwrap().disamb_condition,
-        false
-    );
-}#[cfg(test)]
+#[cfg(test)]
 mod tests {
-    use csln_processor::{load_style_from_file, load_bibliography_from_file};
+    use csln_processor::{load_bibliography_from_file, load_style_from_file};
 
     // create tests for Processor::get_proc_references and Processor::sort_proc_references
     #[test]
@@ -81,7 +11,7 @@ mod tests {
         let proc_references = processor.get_proc_references();
         assert_eq!(proc_references.len(), 5);
         // how can I test the contents of proc_references?
-        assert_eq!(proc_references[0].data.title.as_deref(), Some("A Title"));
-        assert_eq!(proc_references[4].data.title.as_deref(), Some("B Title"));
+        assert_eq!(proc_references[0].data.title.as_deref(), Some("Title 0"));
+        assert_eq!(proc_references[4].data.title.as_deref(), Some("Title 4"));
     }
 }

--- a/processor/tests/processor_test.rs
+++ b/processor/tests/processor_test.rs
@@ -1,4 +1,74 @@
-#[cfg(test)]
+#[test]
+fn test_group_proc_references() {
+    let processor = Processor::new(Bibliography::default(), Style::default());
+    let proc_references = processor.get_proc_references();
+    let grouped_proc_references = processor.group_proc_references(proc_references);
+    assert_eq!(grouped_proc_references.len(), 4);
+    assert_eq!(
+        grouped_proc_references[0].proc_hints.as_ref().unwrap().group_key,
+        "Doe2020"
+    );
+    assert_eq!(
+        grouped_proc_references[0].proc_hints.as_ref().unwrap().group_index,
+        0
+    );
+    assert_eq!(
+        grouped_proc_references[0].proc_hints.as_ref().unwrap().group_length,
+        2
+    );
+    assert_eq!(
+        grouped_proc_references[0].proc_hints.as_ref().unwrap().disamb_condition,
+        false
+    );
+    assert_eq!(
+        grouped_proc_references[1].proc_hints.as_ref().unwrap().group_key,
+        "Doe2021"
+    );
+    assert_eq!(
+        grouped_proc_references[1].proc_hints.as_ref().unwrap().group_index,
+        1
+    );
+    assert_eq!(
+        grouped_proc_references[1].proc_hints.as_ref().unwrap().group_length,
+        1
+    );
+    assert_eq!(
+        grouped_proc_references[1].proc_hints.as_ref().unwrap().disamb_condition,
+        false
+    );
+    assert_eq!(
+        grouped_proc_references[2].proc_hints.as_ref().unwrap().group_key,
+        "Smith2020"
+    );
+    assert_eq!(
+        grouped_proc_references[2].proc_hints.as_ref().unwrap().group_index,
+        2
+    );
+    assert_eq!(
+        grouped_proc_references[2].proc_hints.as_ref().unwrap().group_length,
+        1
+    );
+    assert_eq!(
+        grouped_proc_references[2].proc_hints.as_ref().unwrap().disamb_condition,
+        false
+    );
+    assert_eq!(
+        grouped_proc_references[3].proc_hints.as_ref().unwrap().group_key,
+        "Smith2021"
+    );
+    assert_eq!(
+        grouped_proc_references[3].proc_hints.as_ref().unwrap().group_index,
+        3
+    );
+    assert_eq!(
+        grouped_proc_references[3].proc_hints.as_ref().unwrap().group_length,
+        1
+    );
+    assert_eq!(
+        grouped_proc_references[3].proc_hints.as_ref().unwrap().disamb_condition,
+        false
+    );
+}#[cfg(test)]
 mod tests {
     use csln_processor::{load_style_from_file, load_bibliography_from_file};
 

--- a/processor/tests/processor_test.rs
+++ b/processor/tests/processor_test.rs
@@ -8,10 +8,21 @@ mod tests {
         let style = load_style_from_file("examples/style.csl.yaml");
         let bibliography = load_bibliography_from_file("examples/ex1.bib.yaml");
         let processor = csln_processor::Processor::new(style, bibliography, "en-US".to_string());
-        let proc_references = processor.get_proc_references();
-        assert_eq!(proc_references.len(), 5);
+        let proc_refs = processor.get_proc_references();
+        assert_eq!(proc_refs.len(), 5);
         // how can I test the contents of proc_references?
-        assert_eq!(proc_references[0].data.title.as_deref(), Some("Title 0"));
-        assert_eq!(proc_references[4].data.title.as_deref(), Some("Title 4"));
+        assert_eq!(proc_refs[0].data.title.as_deref(), Some("Title 0"));
+        assert_eq!(proc_refs[4].data.title.as_deref(), Some("Title 4"));
+    }
+
+    #[test]
+    fn test_get_proc_hints() {
+        let style = load_style_from_file("examples/style.csl.yaml");
+        let bibliography = load_bibliography_from_file("examples/ex1.bib.yaml");
+        let processor = csln_processor::Processor::new(style, bibliography, "en-US".to_string());
+        let proc_refs = processor.get_proc_references();
+        assert_eq!(proc_refs.len(), 5);
+        assert_eq!(proc_refs[0].proc_hints.group_index, 1);
+        assert_eq!(proc_refs[1].proc_hints.group_index, 2);
     }
 }

--- a/style/src/options.rs
+++ b/style/src/options.rs
@@ -51,7 +51,8 @@ impl Default for StyleOptions {
                 key: StyleSortGroupKey::Author,
                 order: SortOrder::Ascending,
             }],
-            group: vec![StyleSortGroupKey::Author],
+            group: vec![StyleSortGroupKey::Author,
+                        StyleSortGroupKey::Year],
             substitute: Substitution {
                 author: vec![Substitute::Editor, Substitute::Translator, Substitute::Title],
             },

--- a/style/src/options.rs
+++ b/style/src/options.rs
@@ -59,6 +59,27 @@ impl Default for StyleOptions {
     }
 }
 
+impl StyleOptions {
+    pub fn get_group_key_config(&self) -> &[StyleSortGroupKey] {
+        self.group.as_slice()
+    }
+    pub fn get_contributors_config(&self) -> &StyleContributors {
+        &self.contributors
+    }
+    pub fn get_disambiguation_config(&self) -> &Disambiguation {
+        &self.disambiguate
+    }
+    pub fn get_localization_config(&self) -> &Localization {
+        &self.localization
+    }
+    pub fn get_substitution_config(&self) -> &Substitution {
+        &self.substitute
+    }
+    pub fn get_date_config(&self) -> &StyleDate {
+        &self.dates
+    }
+}
+
 /// Localization configuration.
 ///
 /// Terms and data localization configuration.


### PR DESCRIPTION
EDIT: this is basically working, but the tests aren't passing ATM.

Ideally, I want as little of the processor functions as possible to rely on mutable state. So that means using interators, map, group_by and such to transform data structures: hash -> vector (sort) -> hash? (grouping).

I couldn't get my preferred grouping function using `itertools::group_by` to compile, however, so just used what I could get working for now.

Can optimize later.

Just trying to get the final piece to work, which is ProcHints. I may store those in another HashMap.