### PR TITLE
refactor(proc): remove ProcReference

### DIFF
--- a/bibliography/Cargo.toml
+++ b/bibliography/Cargo.toml
@@ -9,8 +9,8 @@ test = true
 doctest = true
 bench = true
 doc = true
-edition = "2021"       # The edition of the target.
-crate-type = ["lib"]   # The crate types to generate.
+edition = "2021" 
+crate-type = ["lib"] 
 
 [dependencies]
 schemars = "0.8.12"
@@ -18,3 +18,6 @@ serde = "1.0.162"
 serde_derive = "1.0.162"
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"
+chrono = { version = "0.4", features = ["unstable-locales"] }
+style = { path = "../style", package = "csln-style" }
+

--- a/bibliography/src/reference.rs
+++ b/bibliography/src/reference.rs
@@ -1,5 +1,9 @@
 use schemars::{JsonSchema};
+use chrono::NaiveDate;
 use serde::{Serialize, Deserialize};
+use style::template::{
+    Contributors, DateForm, Dates, StyleTemplateContributor,
+};
 //use edtf::DateComplete;
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
@@ -15,3 +19,100 @@ pub struct InputReference {
     pub accessed: Option<String>,
     pub note: Option<String>,
 }
+
+impl InputReference {
+    pub fn new() -> InputReference {
+        InputReference {
+            id: None,
+            title: None,
+            author: None,
+            editor: None,
+            translator: None,
+            issued: None,
+            publisher: None,
+            url: None,
+            accessed: None,
+            note: None,
+        }
+    }
+
+    fn format_names(names: Vec<String>) -> String {
+        let mut name_string = String::new();
+        if names.len() == 1 {
+            name_string = names[0].to_string();
+        } else if names.len() == 2 {
+            name_string = names.join(" and ");
+        } else if names.len() > 2 {
+            let last_author = names.last().unwrap();
+            let other_authors = &names[..names.len() - 1];
+            name_string = other_authors.join(", ");
+            name_string.push_str(", and ");
+            name_string.push_str(last_author);
+        }
+        name_string
+    }
+
+    pub fn format_contributors(&self, template_component: StyleTemplateContributor) -> String {
+        match template_component.contributor {
+            Contributors::Author => {
+                let authors = self
+                    .author
+                    .as_ref()
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .map(|name| name.to_string())
+                    .collect::<Vec<String>>();
+                InputReference::format_names(authors)
+            }
+            Contributors::Editor => {
+                let editors = self
+                    .editor
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|editor| editor.to_string())
+                    .collect::<Vec<String>>();
+                InputReference::format_names(editors)
+            }
+            Contributors::Translator => {
+                let translators = self
+                    .translator
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|translator| translator.to_string())
+                    .collect::<Vec<String>>();
+                InputReference::format_names(translators)
+            }
+            Contributors::Director => todo!(),
+            Contributors::Recipient => todo!(),
+            Contributors::Interviewer => todo!(),
+            Contributors::Interviewee => todo!(),
+            Contributors::Inventor => todo!(),
+            Contributors::Counsel => todo!(),
+            Contributors::Composer => todo!(),
+            Contributors::Publisher => todo!(),
+        }
+    }
+
+    pub fn format_date(&self, date: Dates, form: DateForm) -> String {
+        let date_string: &str = match date {
+            Dates::Issued => self.issued.as_ref().unwrap(),
+            Dates::Accessed => todo!(),
+            Dates::OriginalPublished => todo!(),
+        };
+
+        let format_string: &str = match form {
+            DateForm::Year => "%Y",
+            DateForm::YearMonth => "%Y-%m",
+            DateForm::Full => "%Y-%m-%d",
+            DateForm::MonthDay => "%m-%d",
+        };
+
+        // use EDTF instead?
+        let date: NaiveDate = NaiveDate::parse_from_str(date_string, "%Y-%m-%d").unwrap();
+        let formatted_date: String = date.format(format_string).to_string();
+        formatted_date
+    }
+}
+

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -19,7 +19,6 @@ serde_derive = "1.0.162"
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"
 edtf = "0.2.0"
-chrono = { version = "0.4", features = ["unstable-locales"] }
 style = { path = "../style", package = "csln-style" }
 bibliography = { path = "../bibliography", package = "csln-bibliography" }
 itertools = "0.10.5"

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -1,4 +1,3 @@
-use chrono::NaiveDate;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -9,6 +8,7 @@ use std::option::Option;
 use bibliography::InputBibliography as Bibliography;
 use bibliography::InputReference;
 use style::options::{SortOrder, StyleSortGroupKey, StyleSorting};
+#[allow(unused_imports)] // for now
 use style::template::{
     Contributors, DateForm, Dates, StyleTemplateComponent, StyleTemplateContributor,
 };
@@ -264,90 +264,5 @@ impl Processor {
             bibliography,
             locale,
         }
-    }
-}
-
-// REVIEW with recent changes, do we need this, or put the methods directly on InputReference?
-impl ProcReference {
-    fn format_names(names: Vec<String>) -> String {
-        let mut name_string = String::new();
-        if names.len() == 1 {
-            name_string = names[0].to_string();
-        } else if names.len() == 2 {
-            name_string = names.join(" and ");
-        } else if names.len() > 2 {
-            let last_author = names.last().unwrap();
-            let other_authors = &names[..names.len() - 1];
-            name_string = other_authors.join(", ");
-            name_string.push_str(", and ");
-            name_string.push_str(last_author);
-        }
-        name_string
-    }
-
-    pub fn format_contributors(&self, template_component: StyleTemplateContributor) -> String {
-        match template_component.contributor {
-            Contributors::Author => {
-                let authors = self
-                    .data
-                    .author
-                    .as_ref()
-                    .unwrap_or(&Vec::new())
-                    .iter()
-                    .map(|name| name.to_string())
-                    .collect::<Vec<String>>();
-                ProcReference::format_names(authors)
-            }
-            Contributors::Editor => {
-                let editors = self
-                    .data
-                    .editor
-                    .as_ref()
-                    .unwrap()
-                    .iter()
-                    .map(|editor| editor.to_string())
-                    .collect::<Vec<String>>();
-                ProcReference::format_names(editors)
-            }
-            Contributors::Translator => {
-                let translators = self
-                    .data
-                    .translator
-                    .as_ref()
-                    .unwrap()
-                    .iter()
-                    .map(|translator| translator.to_string())
-                    .collect::<Vec<String>>();
-                ProcReference::format_names(translators)
-            }
-            Contributors::Director => todo!(),
-            Contributors::Recipient => todo!(),
-            Contributors::Interviewer => todo!(),
-            Contributors::Interviewee => todo!(),
-            Contributors::Inventor => todo!(),
-            Contributors::Counsel => todo!(),
-            Contributors::Composer => todo!(),
-            Contributors::Publisher => todo!(),
-        }
-    }
-
-    pub fn format_date(&self, date: Dates, form: DateForm) -> String {
-        let date_string: &str = match date {
-            Dates::Issued => self.data.issued.as_ref().unwrap(),
-            Dates::Accessed => todo!(),
-            Dates::OriginalPublished => todo!(),
-        };
-
-        let format_string: &str = match form {
-            DateForm::Year => "%Y",
-            DateForm::YearMonth => "%Y-%m",
-            DateForm::Full => "%Y-%m-%d",
-            DateForm::MonthDay => "%m-%d",
-        };
-
-        // use EDTF instead?
-        let date: NaiveDate = NaiveDate::parse_from_str(date_string, "%Y-%m-%d").unwrap();
-        let formatted_date: String = date.format(format_string).to_string();
-        formatted_date
     }
 }


### PR DESCRIPTION
Keep this simpler; move the methods to `InputReference`, and remove this from the processor.

Close: #21