### PR TITLE
Render cleanup

### DIFF
--- a/bibliography/Cargo.toml
+++ b/bibliography/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1.0.162"
 serde_derive = "1.0.162"
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"
+edtf = { version = "0.2.0", features = ["chrono"] }
 chrono = { version = "0.4", features = ["unstable-locales"] }
 style = { path = "../style", package = "csln-style" }
 

--- a/bibliography/src/reference.rs
+++ b/bibliography/src/reference.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use edtf::level_1::Edtf;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use style::template::{
@@ -83,10 +83,25 @@ impl InputReference {
             Contributors::Publisher => todo!(),
         }
     }
+
+    pub fn render_edtf_date(&self, date_string: &str, _format_string: &str) -> String {
+        let edtf_date: Edtf = Edtf::parse(date_string).unwrap();
+        let formatted_date: String = match edtf_date {
+            // TODO need localized date rendering, using format_string
+            Edtf::Date(date) => date.to_string(),
+            Edtf::DateTime { .. } => todo!(),
+            Edtf::Interval { .. } => todo!(),
+            Edtf::IntervalFrom { .. } => todo!(),
+            Edtf::IntervalTo { .. } => todo!(),
+            Edtf::YYear { .. } => todo!(),
+        };
+        formatted_date
+    }
+
     pub fn render_date(&self, template_component: &StyleTemplateDate) -> String {
         let date_string: &str = match template_component.date {
             Dates::Issued => self.issued.as_ref().unwrap(),
-            Dates::Accessed => todo!(),
+            Dates::Accessed => self.accessed.as_ref().unwrap(),
             Dates::OriginalPublished => todo!(),
         };
 
@@ -97,10 +112,7 @@ impl InputReference {
             DateForm::MonthDay => "%m-%d",
         };
 
-        // use EDTF instead?
-        let date: NaiveDate = NaiveDate::parse_from_str(date_string, "%Y-%m-%d").unwrap();
-        let formatted_date: String = date.format(format_string).to_string();
-        formatted_date
+        self.render_edtf_date(date_string, format_string)
     }
 
     pub fn render_title(&self, template_component: &StyleTemplateTitle) -> String {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,6 @@ fn main() {
     let bibliography_path: &String = &args[2];
     let bibliography: Bibliography = load_bibliography_from_file(bibliography_path);
     let processor: Processor = Processor::new(style, bibliography, bibliography_path.to_string());
-    let phints = processor.get_proc_hints();
-    println!("{}", serde_json::to_string_pretty(&phints).unwrap());
+    let rendered_refs = processor.render_references();
+    println!("{}", serde_json::to_string_pretty(&rendered_refs).unwrap());
 }

--- a/processor/examples/style.csl.yaml
+++ b/processor/examples/style.csl.yaml
@@ -21,3 +21,5 @@ bibliography:
   template:
     - contributor: author
       form: long
+    - date: issued
+      form: year

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -60,6 +60,9 @@ pub struct Processor {
     locale: String,
 }
 
+/// The intermediate representation of a StyleTemplate, which is used to render the output.
+pub type ProcTemplate = Vec<ProcTemplateComponent>;
+
 /// The intermediate representation of a StyleTemplateComponent, which is used to render the output.
 /// This struct will have two fields: a StyleComponent and a String.
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
@@ -114,11 +117,11 @@ impl Default for ProcHints {
 impl Processor {
 
     /// Render references to AST.
-    pub fn render_references(&self) -> Vec<ProcTemplateComponent> {
+    pub fn render_references(&self) -> Vec<ProcTemplate> {
         let sorted_references = self.sort_references(self.get_references());
         sorted_references
             .iter()
-            .flat_map(|reference| {
+            .map(|reference| {
                 self.render_reference(reference)
             })
             .collect()

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -136,7 +136,7 @@ impl Processor {
                     })
                     .collect()
             })
-            .unwrap_or_else(|| vec![])
+            .unwrap_or_else(std::vec::Vec::new)
     }
 
     fn render_template_component(


### PR DESCRIPTION
Basic rendering now works so:

1. [X] add it to CLI
2. [X] fix `render_references` so it returns an array of templates (also need to add a type for that)
3. [X] fix what seems to be a input date format issue (see error below)
5. [X] fill out the example style to demonstrate and test better.

Tackle these later:

4. [ ] add `edtf:Date` formatting
7. [ ] add disambiguation from hints
8. [ ] I think I want to remove the outer `templateComponent` property in the AST, but may do later

```js
    {
      "templateComponent": {
        "contributor": "author",
        "form": "long",
        "rendering": null
      },
      "value": "United Nations"
    }
```

---- 

```console
❯ target/debug/csln processor/examples/style.csl.yaml processor/examples/ex1.bib.yaml
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseError(TooShort)', bibliography/src/reference.rs:101:82
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

On EDTF, here's what the parse function returns, so will presumably need to match on this?

```rust
pub enum Edtf {
    DateTime,
    Date,
    YYear,
    Interval,
    IntervalFrom,
    IntervalTo,
}
```

I _think_ I then need to use `chrono` to do the formatting, but I'm not sure:

https://docs.rs/chrono/latest/chrono/#formatting-and-parsing