### PR TITLE
refactor(proc): move file loading to style, bib

### DIFF
--- a/bibliography/src/lib.rs
+++ b/bibliography/src/lib.rs
@@ -1,7 +1,27 @@
 use std::collections::HashMap;
+use std::fs;
 
 mod reference;
 pub use reference::InputReference;
 
 /// A bibliography is a collection of references.
 pub type InputBibliography = HashMap<String, InputReference>;
+
+pub trait HasFile {
+    fn from_file(path: &str) -> Self;
+}
+
+impl HasFile for InputBibliography {
+    /// Load and parse a YAML or JSON bibliography file.
+    fn from_file(bib_path: &str) -> InputBibliography {
+        let contents =
+            fs::read_to_string(bib_path).expect("Failed to read bibliography file");
+        if bib_path.ends_with(".json") {
+            serde_json::from_str(&contents).expect("Failed to parse JSON")
+        } else if bib_path.ends_with(".yaml") || bib_path.ends_with(".yml") {
+            serde_yaml::from_str(&contents).expect("Failed to parse YAML")
+        } else {
+            panic!("Style file must be in YAML or JSON format")
+        }
+    }
+}

--- a/citation/Cargo.toml
+++ b/citation/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+schemars = "0.8.12"
+serde = "1.0.162"
+serde_derive = "1.0.162"
+serde_json = "1.0.96"
+serde_yaml = "0.9.21"

--- a/citation/src/lib.rs
+++ b/citation/src/lib.rs
@@ -1,14 +1,70 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+// originally converted from the typescript source with quicktype
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize, JsonSchema)]
+pub struct Citation {
+    /// Local citation rendering option; aka command or style.
+    /// Both are more general than author-date styles, and can apply to any citation style.
+    pub mode: CitationModeType,
+    /// The string that prefaces a list of citation references.
+    pub prefix: String,
+    /// A vector of CitatoinReference objects.
+    pub references: Vec<CitationReference>,
+    /// A string that follows a list of citation references.
+    pub suffix: String,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[derive(Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum CitationModeType {
+    /// Places the author inline in the text; also known as "narrative" or "in text" citations.
+    Integral,
+    /// Places the author in the citation and/or bibliography or reference entry.
+    #[default]
+    NonIntegral,
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+#[derive(Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CitationReference {
+    /// A string that prefaces the citation reference.
+    pub prefix: String,
+    /// The unique identifier token for the citation reference.
+    pub ref_id: String,
+    /// An array of locator key-values and/or strings.
+    pub suffix: Vec<Locator>,
+}
+
+#[allow(clippy::large_enum_variant)] // REVIEW is this a problem?
+/// A key-value object, or a string.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum Locator {
+    KeyValue(LocatorKeyValue),
+    String(String),
+}
+
+pub type LocatorKeyValue = (LocatorTerm, String);
+
+#[derive(Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum LocatorTerm {
+    Book,
+    Chapter,
+    Column,
+    Figure,
+    Folio,
+    Line,
+    Note,
+    Number,
+    Opus,
+    #[default]
+    Page,
+    Paragraph,
+    Part,
+    Section,
+    SubVerbo,
+    Verse,
+    Volume,
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,3 +21,5 @@ serde_json = "1.0.68"
 style = { path = "../style", package = "csln-style" }
 bibliography = { path = "../bibliography", package = "csln-bibliography" }
 processor = { path = "../processor", package = "csln-processor" }
+citation = { path = "../citation", package = "csln-citation" }
+

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,8 @@
 use bibliography::InputBibliography as Bibliography;
+use bibliography::HasFile;
 use processor::Processor;
 use std::env;
 use style::Style;
-
-use processor::{load_bibliography_from_file, load_style_from_file};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -12,10 +11,10 @@ fn main() {
     }
 
     let style_path: &String = &args[1];
-    let style: Style = load_style_from_file(style_path);
+    let style: Style = Style::from_file(style_path);
 
     let bibliography_path: &String = &args[2];
-    let bibliography: Bibliography = load_bibliography_from_file(bibliography_path);
+    let bibliography: Bibliography = Bibliography::from_file(bibliography_path);
     let processor: Processor = Processor::new(style, bibliography, bibliography_path.to_string());
     let rendered_refs = processor.render_references();
     println!("{}", serde_json::to_string_pretty(&rendered_refs).unwrap());

--- a/cli/src/makeschemas.rs
+++ b/cli/src/makeschemas.rs
@@ -4,22 +4,27 @@ use std::fs::File;
 use std::io::Write;
 
 use style::Style;
-
+use citation::Citation;
 use bibliography::InputBibliography;
 
 fn main() {
     fs::create_dir_all("schemas").unwrap();
 
     let style_schema = schema_for!(Style);
+    let citation_schema = schema_for!(Citation);
     let bib_schema = schema_for!(InputBibliography);
 
     let style_json_output = serde_json::to_string_pretty(&style_schema).unwrap();
+    let citation_json_output = serde_json::to_string_pretty(&citation_schema).unwrap();
     let bib_json_output = serde_json::to_string_pretty(&bib_schema).unwrap();
 
+    let mut citation_file = File::create("schemas/citation.json").unwrap();
     let mut style_file = File::create("schemas/style.json").unwrap();
     let mut bib_file = File::create("schemas/bibliography.json").unwrap();
     style_file.write_all(style_json_output.as_bytes()).unwrap();
+    citation_file.write_all(citation_json_output.as_bytes()).unwrap();
     bib_file.write_all(bib_json_output.as_bytes()).unwrap();
-    println!("Wrote style schema to schemas/style.json");
     println!("Wrote bibliography schema to schemas/bibliography.json");
+    println!("Wrote citation schema to schemas/citation.json");
+    println!("Wrote style schema to schemas/style.json");
 }

--- a/processor/benches/proc_bench.rs
+++ b/processor/benches/proc_bench.rs
@@ -1,13 +1,13 @@
 use bibliography::{InputBibliography as Bibliography};
+use bibliography::HasFile;
 use criterion::{criterion_group, criterion_main, Criterion};
 use csln_processor::Processor;
-use csln_processor::{load_bibliography_from_file, load_style_from_file};
 use style::Style;
 use std::time::Duration;
 
 fn proc_benchmark(c: &mut Criterion) {
-    let style: Style = load_style_from_file("examples/style.csl.yaml");
-    let bibliography: Bibliography = load_bibliography_from_file("examples/ex1.bib.yaml");
+    let style: Style = style::Style::from_file("examples/style.csl.yaml");
+    let bibliography: Bibliography = bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
     let processor: Processor = Processor::new(style, bibliography, "en-US".to_string());
     c.bench_function("sorting references", |b| {
         b.iter(|| {

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -8,7 +8,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::fs;
 use std::option::Option;
 use style::options::StyleOptions;
 use style::options::{MonthOptions, SortOrder, StyleSortGroupKey, StyleSorting};
@@ -28,31 +27,6 @@ The processor takes a style, a bibliography, and a locale, and renders the outpu
 
 The primary target is a JSON AST, represented by the ProcTemplateComponent struct.
  */
-
-/// Load and parse a YAML or JSON style file.
-pub fn load_style_from_file(style_path: &str) -> Style {
-    let contents = fs::read_to_string(style_path).expect("Failed to read style file");
-    if style_path.ends_with(".json") {
-        serde_json::from_str(&contents).expect("Failed to parse JSON")
-    } else if style_path.ends_with(".yaml") || style_path.ends_with(".yml") {
-        serde_yaml::from_str(&contents).expect("Failed to parse YAML")
-    } else {
-        panic!("Style file must be in YAML or JSON format")
-    }
-}
-
-/// Load and parse a YAML or JSON bibliography file.
-pub fn load_bibliography_from_file(bib_path: &str) -> Bibliography {
-    let contents =
-        fs::read_to_string(bib_path).expect("Failed to read bibliography file");
-    if bib_path.ends_with(".json") {
-        serde_json::from_str(&contents).expect("Failed to parse JSON")
-    } else if bib_path.ends_with(".yaml") || bib_path.ends_with(".yml") {
-        serde_yaml::from_str(&contents).expect("Failed to parse YAML")
-    } else {
-        panic!("Style file must be in YAML or JSON format")
-    }
-}
 
 /// The processor struct, which takes a style, a bibliography, and a locale, and renders the output.
 #[derive(Debug, Deserialize, Serialize)]

--- a/processor/tests/processor_test.rs
+++ b/processor/tests/processor_test.rs
@@ -1,12 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use csln_processor::{load_bibliography_from_file, load_style_from_file};
-
+    use bibliography::HasFile;
     // create tests for Processor::get_proc_references and Processor::sort_proc_references
     #[test]
     fn test_sort_references() {
-        let style = load_style_from_file("examples/style.csl.yaml");
-        let bibliography = load_bibliography_from_file("examples/ex1.bib.yaml");
+        let style = style::Style::from_file("examples/style.csl.yaml");
+        let bibliography = bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
         let processor = csln_processor::Processor::new(style, bibliography, "en-US".to_string());
         let refs = processor.get_references();
         let sorted_refs = processor.sort_references(refs);
@@ -17,8 +16,8 @@ mod tests {
 
     #[test]
     fn test_proc_hints() {
-        let style = load_style_from_file("examples/style.csl.yaml");
-        let bibliography = load_bibliography_from_file("examples/ex1.bib.yaml");
+        let style = style::Style::from_file("examples/style.csl.yaml");
+        let bibliography = bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
         let processor = csln_processor::Processor::new(style, bibliography, "en-US".to_string());
         let proc_hints = processor.get_proc_hints();
         assert_eq!(proc_hints["doe7"].group_index, 1);

--- a/style/src/lib.rs
+++ b/style/src/lib.rs
@@ -1,12 +1,27 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs;
 
 pub mod options;
 use options::StyleOptions;
 
 pub mod template;
 use template::StyleTemplateComponent;
+
+impl Style {
+    /// Load and parse a YAML or JSON style file.
+    pub fn from_file(style_path: &str) -> Style {
+        let contents = fs::read_to_string(style_path).expect("Failed to read style file");
+        if style_path.ends_with(".json") {
+            serde_json::from_str(&contents).expect("Failed to parse JSON")
+        } else if style_path.ends_with(".yaml") || style_path.ends_with(".yml") {
+            serde_yaml::from_str(&contents).expect("Failed to parse YAML")
+        } else {
+            panic!("Style file must be in YAML or JSON format")
+        }
+    }
+}
 
 /// The CSL-Next style model.
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]


### PR DESCRIPTION
They don't belong on the processor.

------------

Only thing I'm not fond of is having to add the trait, and only on one, and import it when needed.

I think I'll merge this, but probably want to add a common "traits.rs" file at the meta root.