### PR TITLE
refactor: add csln-types crate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
     "yaml.schemas": {
         "./schemas/style.json": ["/*.csl.yaml"],
         "./schemas/bibliography.json": ["/*.bib.yaml"]
-    }
+    },
+    "rust-analyzer.linkedProjects": [
+        "./types/Cargo.toml",
+        "./types/Cargo.toml"
+    ],
+    "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "cli",
     "bibliography",
+    "types",
     "citation",
     "style",
     "processor",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ More concretely, the goal is a suite of models, libraries and tools that make ex
 - interactive real-time processing for GUI contexts like Zotero
 - easy-to-use style creation wizards, both command-line and web
 
-## The model and CSL 1.0
+## The model
+
+### Influences
+
+1. The [CSL 1.0 specification][CSL-spec] [options][CSL-options], and its template language (aka [layout][CSL-templates] and [rendering elements][CSL-render]), most notably from names, dates, and other formatting.
+2. Patterns observed in the [CSL 1.0 styles repository][CSL-styles].
+3. The [BibLaTeX preamble][BLTX] options.
+
+### Comparison to CSL 1.0 and BibLaTeX
 
 To understand the difference between this model and [CSL 1.0][CSL], look at [style::options][CSLNO]. 
 There, you will note configuration options for many details that in CSL 1.0 are configured within the template language:
@@ -26,6 +34,9 @@ There, you will note configuration options for many details that in CSL 1.0 are 
 - substitution
 
 Plus, I've added `localization` support as such a configuration option group, with the idea it can be more easily-expanded there, than by burdening the template language with those details.
+
+In that sense, this design is closer to [BibLaTeX][BLTX], which has a very long list of flat options that handle much of the configuration. 
+Like that project, here were standardize on [EDTF dates][EDTF].
 
 ## Principles
 
@@ -66,4 +77,11 @@ In particular, it has been optimized for the Zotero use-case, where it provides 
 [CSLNO]: https://github.com/bdarcus/csln/blob/main/style/src/options.rs
 [CSLRS]: https://github.com/zotero/citeproc-rs
 [CSLO]: https://github.com/citation-style-language
+[CSL-spec]: https://docs.citationstyles.org/en/stable/specification.html
+[CSL-styles]: https://github.com/citation-style-language/styles
+[CSL-macros]: https://docs.citationstyles.org/en/stable/specification.html#macros
+[CSL-templates]: https://docs.citationstyles.org/en/stable/specification.html#layout-1
+[CSL-render]: https://docs.citationstyles.org/en/stable/specification.html#rendering-elements
+[CSL-options]: https://docs.citationstyles.org/en/stable/specification.html#options
+[BLTX]: https://github.com/plk/biblatex
 [EDTF]: https://www.loc.gov/standards/datetime/

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -1,3 +1,8 @@
+/* 
+SPDX-License-Identifier: MPL-2.0 
+SPDX-FileCopyrightText: © 2023 Bruce D'Arcus
+*/
+
 #[allow(unused_imports)] // for now
 use bibliography::reference::{Contributor, ContributorList, Name, NameList};
 use bibliography::InputBibliography as Bibliography;

--- a/style/src/options.rs
+++ b/style/src/options.rs
@@ -1,3 +1,9 @@
+/* 
+SPDX-License-Identifier: MPL-2.0 
+SPDX-FileCopyrightText: © 2023 Bruce D'Arcus
+
+This module defines models and traits for basic data types used in CSLN styles and input data.
+*/
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/style/src/options.rs
+++ b/style/src/options.rs
@@ -2,9 +2,9 @@
 //! 
 //! The details are adapted from:
 //! 
-//! 1. The [CSL 1.0 specification][CSL-spec].
-//! 2. Its template language (aka [layout][CSL-templates] and [rendering elements][CSL-render]), most notably from names, dates, and other formatting.
-//! 3. Patterns observed in the [CSL 1.0 styles repository][CSL-styles].
+//! 1. The [CSL 1.0 specification][CSL-spec] [options][CSL-options], and its template language (aka [layout][CSL-templates] and [rendering elements][CSL-render]), most notably from names, dates, and other formatting.
+//! 2. Patterns observed in the [CSL 1.0 styles repository][CSL-styles].
+//! 3. The [BibLaTeX preamble][BLTX] options.
 //! 
 //! In this model, much more logic is configured in these options, and the `template` submodule is comparatively simple. 
 //! The intent is to make it easier to write and maintain styles, as well as softtware that uses them.
@@ -17,11 +17,13 @@
 //! 
 //! Still early, with more work needed on adding options, and testing.
 //! 
-//! [CSL-spec]: https://docs.citationstyles.org/en/stable/specification.html#style-options
+//! [CSL-spec]: https://docs.citationstyles.org/en/stable/specification.html
 //! [CSL-styles]: https://github.com/citation-style-language/styles
 //! [CSL-macros]: https://docs.citationstyles.org/en/stable/specification.html#macros
 //! [CSL-templates]: https://docs.citationstyles.org/en/stable/specification.html#layout-1
 //! [CSL-render]: https://docs.citationstyles.org/en/stable/specification.html#rendering-elements
+//! [CSL-options]: https://docs.citationstyles.org/en/stable/specification.html#options
+//! [BLTX]: https://github.com/plk/biblatex
 //! 
 
 /* 

--- a/style/src/options.rs
+++ b/style/src/options.rs
@@ -1,13 +1,39 @@
+//! This submodule defines the configuration groups and options available in CSLN styles.
+//! 
+//! The details are adapted from:
+//! 
+//! 1. The [CSL 1.0 specification][CSL-spec].
+//! 2. Its template language (aka [layout][CSL-templates] and [rendering elements][CSL-render]), most notably from names, dates, and other formatting.
+//! 3. Patterns observed in the [CSL 1.0 styles repository][CSL-styles].
+//! 
+//! In this model, much more logic is configured in these options, and the `template` submodule is comparatively simple. 
+//! The intent is to make it easier to write and maintain styles, as well as softtware that uses them.
+//! 
+//! ## Style Options
+//! 
+//! The [`StyleOptions`] struct defines the configuration groups and options available in CSLN styles.
+//! 
+//! ## Status
+//! 
+//! Still early, with more work needed on adding options, and testing.
+//! 
+//! [CSL-spec]: https://docs.citationstyles.org/en/stable/specification.html#style-options
+//! [CSL-styles]: https://github.com/citation-style-language/styles
+//! [CSL-macros]: https://docs.citationstyles.org/en/stable/specification.html#macros
+//! [CSL-templates]: https://docs.citationstyles.org/en/stable/specification.html#layout-1
+//! [CSL-render]: https://docs.citationstyles.org/en/stable/specification.html#rendering-elements
+//! 
+
 /* 
 SPDX-License-Identifier: MPL-2.0 
 SPDX-FileCopyrightText: © 2023 Bruce D'Arcus
-
-This module defines models and traits for basic data types used in CSLN styles and input data.
 */
+
+//use std::default;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use super::template::Contributors;
+use crate::template::{Rendering, Contributors};
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
 #[serde(default)]
@@ -197,11 +223,39 @@ pub enum SortOrder {
 #[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct StyleContributors {
+    /// When to display a contributor's name in sort order.
     pub display_as_sort: DisplayAsSort,
+    /// Shorten the list of contributors.
     pub shorten: ShortenListOptions,
+    /// The delimiter or separator to use between contributors.
     pub delimiter: DelimiterOptions,
+    /// Whether to sepaaate the last two contributors with a natural language conjunction, and if so what form it should take.
     pub and: AndOptions,
-    pub label: LabelOptions,
+    /// When and how to display contributor roles.
+    pub role: RoleOptions,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleOptions {
+    /// Contributor roles for which to omit the role description.
+    ///
+    /// The default value is `["author"]`, which omits the role for authors, including for any
+    /// author substitutions.
+    // TODO
+    pub omit: Vec<String>,
+    pub form: Option<ContributorForm>,
+    pub rendering: Option<Rendering>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContributorForm {
+    #[default]
+    Long,
+    Short,
+    Verb,
+    VerbShort,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
@@ -266,10 +320,12 @@ pub enum DelimiterOptions {
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum AndOptions {
     #[default] // REVIEW: is this correct?
     Text,
     Symbol,
+    None,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
@@ -385,10 +441,3 @@ pub struct StyleTemplateContributors {
     pub form: ContributorForm,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum ContributorForm {
-    #[default] // REVIEW: is this correct?
-    Long,
-    Short,
-}

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "csl-types"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+edtf = "0.2.0"
+icu = { version = "1.2.0", features = ["icu_datetime_experimental"] }
+icu_datetime = "1.2.1"
+icu_testdata = { version = "1.2.0", features = ["icu_datetime_experimental"]  }
+citation = { path = "../citation/", package = "csln-citation"}
+bibliography = { path = "../bibliography", package = "csln-bibliography" }
+style = { path = "../style", package = "csln-style" }
+unic-langid = "0.9.1"
+serde = { version = "1.0.164", features = ["derive"] }
+serde_json = "1.0.96"
+serde_yaml = "0.9.21"
+schemars = { version = "0.8.12", features = ["url"] }
+url = "2.4.0"

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,0 +1,318 @@
+/* 
+SPDX-License-Identifier: MPL-2.0 
+SPDX-FileCopyrightText: © 2023 Bruce D'Arcus
+
+This is a small module that defines basic data types and functions for formatting.
+
+Some of the ideas and code are adapted from the `typst-hayagriva` crate.
+ */
+
+use bibliography::reference::InputReference;
+use edtf::level_1::Edtf;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use style::options::StyleOptions;
+use url::Url;
+use std::str::FromStr;
+use std::cmp::Ordering;
+
+/*
+This section almost-completely adapted from HayaGriva.
+
+The primary differences:
+
+1. We use `serde` for serialization and deserialization.
+2. A more general notion of Contributor.
+3. Date is a string, not a struct; either EDTF or literal.
+4. Use a different model for the `Entry` struct.
+5. Use traits for shared functionality.
+ */
+
+/// The data types that can possibly be held by the various fields of an
+/// [`InputReference`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum Value {
+    /// A [Title] containing a canonical value and optionally translations and
+    /// shorthands, all of which are formattable.
+    Title(Title),
+    /// A string to be reproduced as-is.
+    Text(String),
+    /// An integer.
+    Integer(i64),
+    /// A date string, either EDTF or literal.
+    Date(RefDate),
+    /// A Contributor.  The model allows single strings, a person names struct, or a list of either.
+    Contributor(Contributor),
+    /// This could be both an Integer or a Number.
+    IntegerOrText(NumOrStr),
+    /// A range between two integers.
+    Range(std::ops::Range<i64>),
+    // /// A duration (of a song or an performance for example).
+    // Duration(Duration),
+    // /// A part of a period.
+    // TimeRange(std::ops::Range<Duration>),
+    /// URL.
+    Url(Url),
+    /// TODO: couldn''t figure out how to do this right.
+    Language(LangID),
+}
+
+pub type LangID = String;
+
+/*
+Core structs.
+ */
+
+/*
+Traits.
+ */
+pub trait Formattable {
+    fn render(
+        &self,
+        referemce: InputReference,
+        style: StyleOptions,
+    ) -> Option<String>;
+}
+
+pub trait SortAndGroupAble {
+    fn key(&self) -> String;
+}
+
+/*
+Core Trait implementations.
+ */
+
+impl Formattable for Title {
+    fn render(
+        &self,
+        referemce: InputReference,
+        style: StyleOptions,
+    ) -> Option<String> {
+        todo!()
+    }
+}
+
+impl SortAndGroupAble for Title {
+    fn key(&self) -> String {
+        match self {
+            Title::Single(s) => s.to_string(),
+            Title::Multi(m) => {
+                todo!("Implement this")
+            }
+            Title::Structured(s) => {
+                todo!("Implement this")
+            }
+            Title::MultiStructured(m) => {
+                todo!("Implement this")
+            }
+            Title::Shorthand(s, t) => {
+                format!("{} ({})", s, t)
+            }
+        }
+    }
+}
+
+impl Formattable for RefDate {
+    fn render(
+        &self,
+        referemce: InputReference,
+        style: StyleOptions,
+    ) -> Option<String> {
+        match self {
+            RefDate::EdtfString(e) => Some(e.to_string()),
+            RefDate::Literal(s) => Some(s.to_string()),
+        }
+    }
+}
+
+impl SortAndGroupAble for RefDate {
+    fn key(&self) -> String {
+        match self {
+            // In progress; not close to right
+            RefDate::EdtfString(date) => {
+                let parsed_date: Edtf = Edtf::parse(&date.to_string())
+                    .unwrap_or_else(|_| Edtf::from_str("unknown").unwrap());
+                parsed_date.to_string()
+            }
+            RefDate::Literal(date) => date.to_string(),
+        }
+    }
+}
+
+impl Formattable for Contributor {
+    fn render(
+        &self,
+        referemce: InputReference,
+        style: StyleOptions,
+    ) -> Option<String> {
+        // Clone the reference before moving it into the closure.
+        let cloned_reference = referemce;
+        match self {
+            Contributor::SimpleName(s) => Some(s.to_string()),
+            Contributor::StructuredName(n) => {
+                Some(format!("{} {}", n.family_name, n.given_name,))
+            },
+            Contributor::ContributorList(l) => {
+                let rendered: Vec<String> = l.0.iter()
+                    .filter_map(|c| c.render(cloned_reference.clone(), style.clone()))
+                    .collect();
+                Some(rendered.join("; "))
+            }
+        }
+    }
+}
+
+impl SortAndGroupAble for Contributor {
+    fn key(&self) -> String {
+        // In progress.
+        match self {
+            Contributor::SimpleName(s) => s.to_string(),
+            Contributor::StructuredName(n) => {
+                format!("{} {}", n.family_name, n.given_name,)
+            }
+            Contributor::ContributorList(l) => l.0.iter().map(|c| c.key()).collect(),
+        }
+    }
+}
+
+/// A contributor can be a person or an organzation.
+// REVIEW for now, we keep this simple-but-flexible.  We may want to add more structure later.
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+#[serde(untagged)]
+pub enum Contributor {
+    SimpleName(String),
+    StructuredName(StructuredName),
+    ContributorList(ContributorList),
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+pub struct ContributorList(pub Vec<Contributor>);
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StructuredName {
+    pub given_name: String,
+    pub family_name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+#[serde(untagged)]
+pub enum RefDate {
+    EdtfString(EdtfString),
+    Literal(String),
+}
+
+impl Eq for RefDate {}
+
+impl Ord for RefDate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (RefDate::EdtfString(a), RefDate::EdtfString(b)) => a.cmp(b),
+            (RefDate::Literal(a), RefDate::Literal(b)) => a.cmp(b),
+            (RefDate::EdtfString(_), RefDate::Literal(_)) => Ordering::Less,
+            (RefDate::Literal(_), RefDate::EdtfString(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for RefDate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A collection of formattable strings consisting of a title, a translated
+/// title, and a shorthand.
+// TODO: borrow from typescript model/ csl 1.1 branch
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum Title {
+    /// A title in a single language.
+    Single(String),
+    /// A structured title.
+    Structured(StructuredTitle),
+    /// A title in multiple languages.
+    Multi(Vec<(LangID, String)>),
+    /// A title in multiple languages.
+    MultiStructured(Vec<(LangID, StructuredTitle)>),
+    /// A title with a shorthand.
+    Shorthand(String, String),
+}
+
+/// Where title parts are meaningful, use this struct; CSLN processors will not parse title strings.
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+pub struct StructuredTitle {
+    pub full: String,
+    pub main: Option<String>,
+    pub sub: Option<Vec<String>>,
+}
+
+pub type EdtfString = String;
+
+impl RefDate {
+    pub fn year(&self) -> Option<String> {
+        match self {
+            RefDate::EdtfString(date) => {
+                let parsed_date: Edtf = match Edtf::parse(&date.to_string()) {
+                    Ok(edtf) => edtf,
+                    Err(_) => return None,
+                };
+                Some(parsed_date.as_date().unwrap().year().to_string())
+            }
+            RefDate::Literal(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for RefDate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RefDate::EdtfString(date) => {
+                let parsed_date: Edtf = match Edtf::parse(&date.to_string()) {
+                    Ok(edtf) => edtf,
+                    Err(_) => return write!(f, "{}", date),
+                };
+                write!(f, "{}", parsed_date)
+            }
+            RefDate::Literal(date) => write!(f, "{}", date),
+        }
+    }
+}
+
+/// A value that could be either a number or a string.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum NumOrStr {
+    /// It's a number!
+    Number(i64),
+    /// It's a string!
+    Str(String),
+}
+
+impl fmt::Display for NumOrStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Self::Number(i) => write!(f, "{}", i),
+            Self::Str(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl From<NumOrStr> for String {
+    fn from(num: NumOrStr) -> Self {
+        num.to_string()
+    }
+}
+
+impl From<NumOrStr> for i64 {
+    fn from(num: NumOrStr) -> Self {
+        match num {
+            NumOrStr::Number(i) => i,
+            NumOrStr::Str(s) => s.parse().unwrap_or(0),
+        }
+    }
+}


### PR DESCRIPTION
An experiment ATM, that I'm merging for now. But it's not hooked up, and it needs work.

Adapt a few ideas, and some code, from Hayagriva, and separate out basic data types and formatting code from bibliography and processor.

I think ideally I want all the basic formatting of these datatypes to be here too, so the models become clean, and also easier to contribute to for non-programmers or rust devs, and it's all more modular.

For titles, adapted this from the ts model, which in turn is adapted from the CSL 1.1 branch xml schema.

```typescript
export interface TitleStructured {
  full?: TitleString;
  main: TitleString;
  sub: TitleString[];
}
```

Still unsure on traits vs straight functions, etc. Masto response back-and-forth is very useful.

https://fosstodon.org/@digikata/110515566415939721

Here's one of the suggested examples to examine:

https://github.com/obsidiandynamics/stanza/blob/master/src/renderer.rs

And the markdown renderer:

https://github.com/obsidiandynamics/stanza/blob/master/src/renderer/markdown.rs

https://docs.rs/tabled/latest/tabled/

May want to consider this on sorting:

https://stackoverflow.com/questions/60916194/how-to-sort-a-vector-in-descending-order-in-rust/60916195#60916195