### PR TITLE
types cleanup, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ More concretely, the goal is a suite of models, libraries and tools that make ex
 - interactive real-time processing for GUI contexts like Zotero
 - easy-to-use style creation wizards, both command-line and web
 
+## Principles
+
+For the `Style` model:
+
+1. Keep the template language as simple as possible, in the hopes we can keep it stable going forward, while still enabling innnovation.
+2. Add new functionality primarily via option groups.
+
+For the `InputReference` and `Citation` models:
+
+3. No string-parsing, with the sole exception of the [EDTF date format][EDTF], which is now ISO-standardized as an extension profile of ISO 8601, with well-defined parsing rules, and parsing libraries available in multiple languages.
+4. Provide structure where needed, but offer alternatives where not. EDTF is available for diverse date-time encoding, but dates fields will fallback to a plain string. Likewise, the `Contributor` model offers similar flexibility, and power where needed.
+
 ## The model
 
 ### Influences
@@ -36,19 +48,7 @@ There, you will note configuration options for many details that in CSL 1.0 are 
 Plus, I've added `localization` support as such a configuration option group, with the idea it can be more easily-expanded there, than by burdening the template language with those details.
 
 In that sense, this design is closer to [BibLaTeX][BLTX], which has a very long list of flat options that handle much of the configuration. 
-Like that project, here were standardize on [EDTF dates][EDTF].
-
-## Principles
-
-For the `Style` model:
-
-1. Keep the template language as simple as possible, in the hopes we can keep it stable going forward, while still enabling innnovation.
-2. Add new functionality primary via option groups.
-
-For the `InputReference` and `Citation` models:
-
-3. No string-parsing, with the sole exception of the [EDTF date format][EDTF], which is now ISO-standardized as an extension profile of ISO 8601, with well-defined parsing rules, and parsing libraries available in multiple languages.
-4. Provide structure where needed, but offer alternatives where not. EDTF is available for diverse date-time encoding, but dates fields will fallback to a plain string. Likewise, the `Contributor` model offers similar flexibility, and power where needed.
+Like that project, here we standardize on [EDTF dates][EDTF].
 
 ## Project Organization
 


### PR DESCRIPTION
Will hopefully stabilize this and hook it up here.

Thinking about changing it from `csl-types` to `csl-core`.