### PR TITLE
edtf date-time formatting

### DIFF
--- a/processor/examples/locale-en.yaml
+++ b/processor/examples/locale-en.yaml
@@ -1,0 +1,35 @@
+---
+locale: en
+month:
+  long:
+    1: January
+    2: February
+    3: March
+    4: April
+    5: May
+    6: June
+    7: July
+    8: August
+    9: September
+    10: October
+    11: November
+    12: December
+  short:
+    1: Jan
+    2: Feb
+    3: Mar
+    4: Apr
+    5: May
+    6: Jun
+    7: Jul
+    8: Aug
+    9: Sep
+    10: Oct
+    11: Nov
+    12: Dec
+month-day:
+  delimter: " "
+  order:
+    - month
+    # - conjunction: de for spanish
+    - day

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -452,9 +452,9 @@ impl Processor {
                 }
                 SortGroupKey::Year => {
                     references.par_sort_by(|a, b| {
-                        let a_year = a.issued.as_ref().unwrap().year();
-                        let b_year = b.issued.as_ref().unwrap().year();
-                        //println!("a_year: {}", a_year);
+                        let a_year = a.issued.as_ref().unwrap().parse().year();
+                        let b_year = b.issued.as_ref().unwrap().parse().year();
+                        // println!("a_year: {}", b_year);
                         if sort.order == SortOrder::Ascending {
                             a_year.cmp(&b_year)
                         } else {
@@ -515,7 +515,8 @@ impl Processor {
             .par_iter()
             .map(|key| match key {
                 SortGroupKey::Author => reference.author.as_ref().unwrap().names(options.clone(), as_sorted),
-                SortGroupKey::Year => reference.issued.as_ref().unwrap().year().unwrap_or_default().to_string(),
+                // REVIEW: maybe better to sort on the integer?
+                SortGroupKey::Year => reference.issued.as_ref().unwrap().parse().year().to_string(),
                 SortGroupKey::Title => reference.title.as_ref().unwrap().to_string(),
             })
             .collect::<Vec<String>>()


### PR DESCRIPTION
Like my fifth attempt at this ....

I've decided to add my own methods to parse edtf date-times, and also convert them to the sort of input formats needed by chrono or icu.

The first commit here adds those.

The parsing method returns an `Edtf::Date` regardless of whether it's valid, but if it's not, it's a dummy date with zero year.

Maybe there's a better way, but it'll do for now.

But this currently ONLY handles `edtf:Date`, so still work to do.