### PR TITLE
feat(bib): date methods

### DIFF
--- a/processor/examples/style.csl.yaml
+++ b/processor/examples/style.csl.yaml
@@ -24,3 +24,6 @@ bibliography:
     - date: issued
       form: year
     - title: title
+    - date: issued
+      form: month-day
+

--- a/style/src/locale.rs
+++ b/style/src/locale.rs
@@ -81,12 +81,14 @@ pub struct MonthNames {
     /// The ordered list of full month names.
     /// The list must contain exactly 12 elements.
     #[validate(range(min = 12, max = 12))]
-    pub long: Vec<String>,
+    pub long: MonthList,
     /// The ordered list of abbreviated month names.
     /// The list must contain exactly 12 elements.
     #[validate(range(min = 12, max = 12))]
-    pub short: Vec<String>,
+    pub short: MonthList,
 }
+
+pub type MonthList = Vec<String>;
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "kebab-case")]


### PR DESCRIPTION
This branch implements a custom date type and associated methods for formatting them.

Code now compiles, the tests pass, and processor works for basic dates.

Issues to fix (though I may do that later):

1. type errors when I try to implement other EDTF date-times on the month etc methods; the kind of thing about Rust that just drives me insane!
2. when non-EDTF input, need to get a meaningful string to the output