### PR TITLE
refactor: sort/group -> processing

### DIFF
--- a/processor/examples/style.csl.yaml
+++ b/processor/examples/style.csl.yaml
@@ -1,15 +1,8 @@
 ---
 info:
   title: APA
-options:
-  sort: 
-    template:
-      - key: author
-      - key: year
-  group: 
-    template:
-      - author
-      - year
+options: 
+  processing: author-date # this sets sorting and grouping for author-date
 templates:
   title-apa:
     - title: title


### PR DESCRIPTION
Threw out initial idea here, and instead refactored to allow:

```yaml
processing: author-date # combines sorting and grouping config
```

Close #83