### PR TITLE
Refactor subtitles and SimpleName Contributor

### DIFF
--- a/bibliography/Cargo.toml
+++ b/bibliography/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
-url = { version = "2", features = ["serde"] }
+url = { version = "2.4.0", features = ["serde"] }
 edtf = { version = "0.2", features = ["chrono"] }
 chrono = { version = "0.4", features = ["unstable-locales"] }
 style = { path = "../style", package = "csln-style" }

--- a/bibliography/src/reference.rs
+++ b/bibliography/src/reference.rs
@@ -34,6 +34,8 @@ use url::Url;
 /// The Reference model.
 pub struct InputReference {
     pub id: Option<String>,
+    // Make this an option, since we don't want to rely on it.
+    pub r#type: Option<RefType>,
     pub title: Option<Title>,
     pub author: Option<Contributor>,
     pub editor: Option<Contributor>,
@@ -43,6 +45,28 @@ pub struct InputReference {
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+pub enum RefType {
+    #[default]
+    Article,
+    Book,
+    Chapter,
+    Dataset,
+    Document,
+    Entry,
+    JournalArticle,
+    Manuscript,
+    Map,
+    Patent,
+    PersonalCommunication,
+    Report,
+    Review,
+    Software,
+    Thesis,
 }
 
 /// A locale string.

--- a/processor/examples/chicago.bib.yaml
+++ b/processor/examples/chicago.bib.yaml
@@ -1,0 +1,118 @@
+---
+# some exmples from Chicago
+biss:
+  type: book
+  author: 
+    family: Bissell
+    given: Tom
+  issued: "2011"
+  title: 
+    main: Extra Lives
+    sub: Why Video Games Matter
+  publisher: 
+    location: New York
+    name: Vintage Books
+hutt:
+  type: book
+  author: 
+    family: Hutter
+    given: Michael
+  issued: "2011"
+  title: 
+    main: Infinite Surprises
+    sub: Value in the Creative Industries
+  containerTitle: 
+    main: The Worth of Goods
+    sub: Valuation and Pricing in the Economy
+  editor: 
+    - family: Beckert
+      given: Jens
+    - family: Aspers
+      given: Patrick
+  pages: 201-220
+  publisher:
+    location: New York
+    name: Oxford University Press.
+lamp:
+  type: journal-article
+  author:
+    - family: Lampel
+      given: Joseph
+    - family: Lant
+      given: Theresa
+    - family: Shamsie
+      given: Jamal
+  isued: "2000"
+  title: 
+    main: Balancing Act
+    sub: Learning from Organizing Practices in Cultural Industries
+  containerTitle: Organization Science
+  volume: 11 
+  issue: 3
+  pages: 263-269
+daum:
+  type: book
+  editor:
+    family: Daum
+    given: Meghan
+  issued: '2015'
+  title:
+    main: Selfish, Shallow, and Self-Absorbed
+    sub: Sixteen Writers on the Decision Not to Have Kids
+  publisher: 
+    name: Picador
+    location: New York
+liu:
+  type: journal-article
+  author:
+    family: Liu
+    given: Jui-Ch’i
+  issued: '2015-24'
+  title:
+    main: Beholding the Feminine Sublime
+    sub: Lee Miller’s War Photography
+  containerTitle: Signs
+  volume: 40
+  issue: 2 # printed as 'no. 2'; not sure why
+  pages: '308-19'
+  doi: 10.1086/678242
+gund:
+  # 15.48 exception:
+  type: journal-article
+  author:
+  -  family: Gunderson
+     given: Alex R
+  - family: Leal
+    given: Manuel
+  issued: '2015-05'
+  title: Patterns of Thermal Constraint on Ectotherm Activity
+  containerTitle: American Naturalist
+  issue: 185 # no volume, so preface with label to disambiguate
+  pages: 653–64
+  doi: 10.1086/680849
+glass:
+  author:
+  - family: Glass
+    given: Jennifer
+  - family: Levchak
+    given: Philip
+  issued: '2014'
+  title:
+    main: Red States, Blue States, and Divorce
+    sub: Understanding the Impact of Conservative Protestantism on Regional Variation in Divorce Rates
+  containerTitle: American Journal of Sociology
+  volume: 119
+  issue: 4
+  pages: 1002–46
+  doi: 10.1086/674703
+meyer:
+  # 15.47 exception (only an issue number, no volume):
+  author: 
+    family: Meyerovitch
+    given: Eva
+  issued: '1959'
+  title: The Gnostic Manuscripts of Upper Egypt
+  containerTitle: Diogenes
+  issue: 25
+  pages: 84–117
+

--- a/processor/examples/ex1.bib.yaml
+++ b/processor/examples/ex1.bib.yaml
@@ -2,142 +2,192 @@
 un:
   type: article
   title: Title 4
-  author: ["United Nations"]
+  author:
+    name: United Nations
   issued: '2020'
 smith1:
   type: book
   title: Title 3
-  author: ["Smith, Sam"]
+  author:
+    family: Smith
+    given: John
   issued: '2023-10'
 doe1:
   type: book
   title: Title 2
-  author: ["Doe, Jane"]
+  author:
+    family: Doe
+    given: Jane
   issued: '2023-10'
 doe2:
   type: book
   title: Title 1
-  author: ["Doe, Jane"]
+  author:
+    family: Doe
+    given: Jane
   issued: '2020'
 doe3:
   type: article
   title: Title 0
-  author: ["Doe, Jane"]
+  author: 
+    family: Doe
+    given: Jane
   issued: '2020'
 brown1:
   type: article
   title: Title 5
-  author: ["Brown, John"]
+  author: 
+    name: Brown, John
   issued: '2021'
 lee1:
   type: book
   title: Title 6
-  author: ["Lee, Sarah"]
+  author:
+    family: Lee
+    given: Sarah
   issued: '2022'
 lee2:
   type: article
   title: Title 7
-  author: ["Lee, Sarah"]
+  author: 
+    family: Lee
+    given: Sarah
   issued: '2022'
 miller1:
   type: book
   title: Title 8
-  author: ["Miller, David"]
+  author: 
+    family: Miller
+    given: David
   issued: '2018'
 miller2:
   type: article
   title: Title 9
-  author: ["Miller, David"]
+  author: 
+    family: Miller
+    given: David
   issued: '2018'
 jones1:
   type: book
   title: Title 10
-  author: ["Jones, Michael"]
+  author:
+    family: Jones
+    given: Michael
   issued: '2022'
 jones2:
   type: article
   title: Title 11
-  author: ["Jones, Michael"]
+  author: 
+    family: Jones
+    given: Michael
   issued: '2022'
 smith2:
   type: book
   title: Title 12
-  author: ["Smith, John"]
+  author: 
+    family: Smith
+    given: John
   issued: '2020'
 smith3:
   type: article
   title: Title 13
-  author: ["Smith, John"]
+  author: 
+    family: Smith
+    given: John
   issued: '2020'
 miller3:
   type: book
   title: Title 14
-  author: ["Miller, Sarah"]
+  author: 
+    family: Miller
+    given: Sarah
   issued: '2017'
 miller4:
   type: article
   title: Title 15
-  author: ["Miller, Sarah"]
+  author: 
+    family: Miller
+    given: Sarah
   issued: '2018'
 jones3:
   type: book
   title: Title 16
-  author: ["Jones, David"]
+  author: 
+    name: Jones, David
   issued: '2019'
 jones4:
   type: article
   title: Title 17
-  author: ["Jones, David"]
+  author: 
+    name: Jones, David
   issued: '2019'
 brown2:
   type: book
   title: Title 18
-  author: ["Brown, Sarah"]
+  author: 
+    name: Brown, Sarah
   issued: '2019'
 brown3:
   type: article
   title: Title 19
-  author: ["Brown, Sarah"]
+  author:
+    name: Brown, Sarah
   issued: '2019'
 lee3:
   type: book
   title: Title 20
-  author: ["Lee, David"]
+  author: 
+    family: Lee
+    given: David
   issued: '2006'
 lee4:
   type: article
   title: Title 21
-  author: ["Lee, David"]
+  author: 
+    family: Lee
+    given: David
   issued: '2006'
 doe4:
   type: book
   title: Title 22
-  author: ["Doe, John"]
+  author: 
+    family: Doe
+    given: John
   issued: '2013'
 doe5:
   type: article
   title: Title 23
-  author: ["Doe, John"]
+  author: 
+    family: Doe
+    given: John
   issued: '2013'
 smith4:
   type: book
   title: Title 24
-  author: ["Smith, Sarah"]
+  author: 
+    family: Smith
+    given: Sarah
   issued: '2014'
 smith5:
   type: article
   title: Title 25
-  author: ["Smith, Sarah"]
+  author: 
+    family: Smith
+    given: Sarah
   issued: '2015'
 miller5:
   type: book
   title: Title 26
-  author: ["Miller, John"]
+  author: 
+    family: Miller
+    given: John
   issued: '2016'
 miller6:
   type: article
   title: Title 27
-  author: ["Miller, John"]
+  author:
+    family: Miller
+    given: John
   issued: '2032'
 jones5:
   type: book
@@ -145,48 +195,57 @@ jones5:
   # for single author pieces, there's no point in a list
   # but if we need structured data, as we do with Western names,let's structure it
   author:
-    familyName: Doe
-    givenName: Jane
+    family: Doe
+    given: Jane
   issued: '2018'
 jones6:
   type: article
   title: Title 29
   author:
-    familyName: Jones
-    givenName: Sarah
+    family: Jones
+    given: Sarah
   issued: '2018'
 brown4:
   type: book
   title: Title 30
-  author: ["Brown, David"]
+  author: 
+    family: Brown
+    given: David
   issued: '2021'
 brown5:
   type: article
   title: Title 31
   # here we need a list
   author:
-    - familyName: Brown
-      givenName: David
-    - familyName: Lee
-      givenName: Jane
+    - family: Brown
+      given: David
+    - family: Lee
+      given: Jane
   issued: '2021'
 lee5:
   type: book
   title: Title 32
-  author: ["Lee, John"]
+  author: 
+    name: Lee, John
   issued: '2022'
 lee6:
   type: article
   title: Title 33
-  author: ["Lee, John"]
+  author: 
+    family: Lee
+    given: John
   issued: '2022'
 doe6:
   type: book
   title: Title 34
-  author: ["Doe, Sarah"]
+  author:
+    family: Doe
+    given: Sarah
   issued: 'non-EDTF date'
 doe7:
   type: article
   title: Title 35
-  author: ["Doe, Sarah"]
+  author: 
+    family: Doe
+    given: Sarah
   issued: '2009'


### PR DESCRIPTION
Allows:

```yaml
title:
  main: A title
  sub: A subtitle # can also be a vector of strings
```

```yaml
author:
  name: United Nations
title: Some string title # titles can also be simple strings
publisher: # as with all contributors, this can also be a vector of more than one
  name: ABC Books
  location: New York
```

I may also want to add:

```yaml
access:
  url: ...
  date: 2020-10-11
```

Close #90

Any feedback on this @denismaier, before I merge it?