### PR TITLE
refactor(bib)!: make InputReference an enum

### DIFF
--- a/bibliography/Cargo.toml
+++ b/bibliography/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
-url = { version = "2", features = ["serde"] }
+url = { version = "2.4.0", features = ["serde"] }
 edtf = { version = "0.2", features = ["chrono"] }
 chrono = { version = "0.4", features = ["unstable-locales"] }
 style = { path = "../style", package = "csln-style" }

--- a/bibliography/Cargo.toml
+++ b/bibliography/Cargo.toml
@@ -26,4 +26,5 @@ chrono = { version = "0.4", features = ["unstable-locales"] }
 style = { path = "../style", package = "csln-style" }
 icu = { version = "1.2.0", features = ["icu_datetime_experimental"] }
 icu_testdata = { version = "1.2.0", features = ["icu_datetime_experimental"] }
+indexmap = { version = "2.0.0", features = ["std"] }
 

--- a/bibliography/README.md
+++ b/bibliography/README.md
@@ -1,8 +1,3 @@
 This is a Rust library that implements the [csl-next](https://github.com/bdarcus/csl-next) bibliography model.
 
-It is not yet fully-aligned with that model, and I will likely adjust both.
-
-Note also that both models are more place-holders than anything; there are still a lot of decisions to make on the modeling. 
-But this is enough to build out the other functionality.
-
 The `csln-schemas` binary will generate the input JSON schemas.

--- a/bibliography/src/lib.rs
+++ b/bibliography/src/lib.rs
@@ -5,8 +5,6 @@ pub mod reference;
 pub use reference::InputReference;
 
 /// A bibliography is a collection of references.
-// This would likely be as an IndexMap, sorted upon creation.
-// But needs to be compatible with serde_yaml and serde_json, and the auto schema creation.
 pub type InputBibliography = HashMap<String, InputReference>;
 
 // REVIEW move this to a core traits.rs module?

--- a/bibliography/src/reference.rs
+++ b/bibliography/src/reference.rs
@@ -34,6 +34,8 @@ use url::Url;
 /// The Reference model.
 pub struct InputReference {
     pub id: Option<String>,
+    // Make this an option, since we don't want to rely on it.
+    pub r#type: Option<RefType>,
     pub title: Option<Title>,
     pub author: Option<Contributor>,
     pub editor: Option<Contributor>,
@@ -43,6 +45,28 @@ pub struct InputReference {
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+pub enum RefType {
+    #[default]
+    Article,
+    Book,
+    Chapter,
+    Dataset,
+    Document,
+    Entry,
+    JournalArticle,
+    Manuscript,
+    Map,
+    Patent,
+    PersonalCommunication,
+    Report,
+    Review,
+    Software,
+    Thesis,
 }
 
 /// A locale string.

--- a/bibliography/src/reference.rs
+++ b/bibliography/src/reference.rs
@@ -34,6 +34,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use style::{locale::MonthList, options::Config};
 use url::Url;
+use fmt::Display;
+use std::fmt::Formatter;
 //use icu::calendar::DateTime;
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
@@ -136,6 +138,26 @@ impl InputReference {
     }
 }
 
+/// A value that could be either a number or a string.
+// Borrowed from Hayagriva
+#[derive(Clone, Debug, PartialEq, Eq, JsonSchema, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumOrStr {
+    /// It's a number!
+    Number(i64),
+    /// It's a string!
+    Str(String),
+}
+
+impl Display for NumOrStr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Self::Number(i) => write!(f, "{}", i),
+            Self::Str(s) => write!(f, "{}", s),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 /// A monograph, such as a book or a report, is a monolithic work published or produced as a complete entity.
 pub struct Monograph {
@@ -149,6 +171,9 @@ pub struct Monograph {
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
+    pub isbn: Option<String>,
+    pub doi: Option<String>,
+    pub edition: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
@@ -164,6 +189,7 @@ pub struct Collection {
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
+    pub issn: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
@@ -191,6 +217,10 @@ pub struct SerialComponent {
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
+    pub doi: Option<String>,
+    pub pages: Option<String>,
+    pub volume: Option<NumOrStr>,
+    pub issue: Option<NumOrStr>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
@@ -244,6 +274,7 @@ pub struct MonographComponent {
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
+    pub doi: Option<String>,
 }
 
 pub type RefID = String;
@@ -273,6 +304,7 @@ pub enum MonographType {
 #[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
+// TODO merge into refactor
 pub enum RefType {
     #[default]
     Article,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,12 +1,12 @@
-use bibliography::InputBibliography as Bibliography;
 use bibliography::HasFile;
+use bibliography::InputBibliography as Bibliography;
 use citation::Citation;
+use clap::Parser;
 use processor::Processor;
 use style::Style;
-use clap::Parser;
 
-#[derive(Parser,Default,Debug)] 
-#[clap(author="Bruce D'Arcus", version, about="A CLI for CSLN")]
+#[derive(Parser, Default, Debug)]
+#[clap(author = "Bruce D'Arcus", version, about = "A CLI for CSLN")]
 pub struct Opts {
     #[clap(short, long)]
     /// The path to the CSLN style file

--- a/cli/src/makeschemas.rs
+++ b/cli/src/makeschemas.rs
@@ -3,10 +3,10 @@ use std::fs;
 use std::fs::File;
 use std::io::Write;
 
-use style::Style;
-use citation::CitationList;
 use bibliography::InputBibliography;
+use citation::CitationList;
 use style::locale::Locale;
+use style::Style;
 
 fn main() {
     fs::create_dir_all("schemas").unwrap();

--- a/processor/benches/proc_bench.rs
+++ b/processor/benches/proc_bench.rs
@@ -1,14 +1,15 @@
-use bibliography::{InputBibliography as Bibliography};
 use bibliography::HasFile;
+use bibliography::InputBibliography as Bibliography;
 use citation::Citation;
 use criterion::{criterion_group, criterion_main, Criterion};
 use csln_processor::Processor;
-use style::Style;
 use std::time::Duration;
+use style::Style;
 
 fn proc_benchmark(c: &mut Criterion) {
     let style: Style = style::Style::from_file("examples/style.csl.yaml");
-    let bibliography: Bibliography = bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
+    let bibliography: Bibliography =
+        bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
     let locale = style::locale::Locale::from_file("locales/locale-en.yaml");
     let citations: Vec<Citation> = Vec::new();
     let processor: Processor = Processor::new(style, bibliography, citations, locale);

--- a/processor/examples/chicago.bib.yaml
+++ b/processor/examples/chicago.bib.yaml
@@ -1,0 +1,118 @@
+---
+# some exmples from Chicago
+biss:
+  type: book
+  author: 
+    family: Bissell
+    given: Tom
+  issued: "2011"
+  title: 
+    main: Extra Lives
+    sub: Why Video Games Matter
+  publisher: 
+    location: New York
+    name: Vintage Books
+hutt:
+  type: book
+  author: 
+    family: Hutter
+    given: Michael
+  issued: "2011"
+  title: 
+    main: Infinite Surprises
+    sub: Value in the Creative Industries
+  containerTitle: 
+    main: The Worth of Goods
+    sub: Valuation and Pricing in the Economy
+  editor: 
+    - family: Beckert
+      given: Jens
+    - family: Aspers
+      given: Patrick
+  pages: 201-220
+  publisher:
+    location: New York
+    name: Oxford University Press.
+lamp:
+  type: journal-article
+  author:
+    - family: Lampel
+      given: Joseph
+    - family: Lant
+      given: Theresa
+    - family: Shamsie
+      given: Jamal
+  isued: "2000"
+  title: 
+    main: Balancing Act
+    sub: Learning from Organizing Practices in Cultural Industries
+  containerTitle: Organization Science
+  volume: 11 
+  issue: 3
+  pages: 263-269
+daum:
+  type: book
+  editor:
+    family: Daum
+    given: Meghan
+  issued: '2015'
+  title:
+    main: Selfish, Shallow, and Self-Absorbed
+    sub: Sixteen Writers on the Decision Not to Have Kids
+  publisher: 
+    name: Picador
+    location: New York
+liu:
+  type: journal-article
+  author:
+    family: Liu
+    given: Jui-Ch’i
+  issued: '2015-24'
+  title:
+    main: Beholding the Feminine Sublime
+    sub: Lee Miller’s War Photography
+  containerTitle: Signs
+  volume: 40
+  issue: 2 # printed as 'no. 2'; not sure why
+  pages: '308-19'
+  doi: 10.1086/678242
+gund:
+  # 15.48 exception:
+  type: journal-article
+  author:
+  -  family: Gunderson
+     given: Alex R
+  - family: Leal
+    given: Manuel
+  issued: '2015-05'
+  title: Patterns of Thermal Constraint on Ectotherm Activity
+  containerTitle: American Naturalist
+  issue: 185 # no volume, so preface with label to disambiguate
+  pages: 653–64
+  doi: 10.1086/680849
+glass:
+  author:
+  - family: Glass
+    given: Jennifer
+  - family: Levchak
+    given: Philip
+  issued: '2014'
+  title:
+    main: Red States, Blue States, and Divorce
+    sub: Understanding the Impact of Conservative Protestantism on Regional Variation in Divorce Rates
+  containerTitle: American Journal of Sociology
+  volume: 119
+  issue: 4
+  pages: 1002–46
+  doi: 10.1086/674703
+meyer:
+  # 15.47 exception (only an issue number, no volume):
+  author: 
+    family: Meyerovitch
+    given: Eva
+  issued: '1959'
+  title: The Gnostic Manuscripts of Upper Egypt
+  containerTitle: Diogenes
+  issue: 25
+  pages: 84–117
+

--- a/processor/examples/chicago.bib.yaml
+++ b/processor/examples/chicago.bib.yaml
@@ -13,28 +13,31 @@ biss:
     location: New York
     name: Vintage Books
 hutt:
-  type: book
+  type: chapter
+  issued: "2011"
   author: 
     family: Hutter
     given: Michael
-  issued: "2011"
   title: 
     main: Infinite Surprises
     sub: Value in the Creative Industries
-  containerTitle: 
-    main: The Worth of Goods
-    sub: Valuation and Pricing in the Economy
-  editor: 
-    - family: Beckert
-      given: Jens
-    - family: Aspers
-      given: Patrick
+  parent:
+    type: book
+    issued: "2011" # currerntly required in both places
+    title: 
+      main: The Worth of Goods
+      sub: Valuation and Pricing in the Economy
+    editor: 
+      - family: Beckert
+        given: Jens
+      - family: Aspers
+        given: Patrick
+    publisher:
+      location: New York
+      name: Oxford University Press
   pages: 201-220
-  publisher:
-    location: New York
-    name: Oxford University Press.
 lamp:
-  type: journal-article
+  type: article
   author:
     - family: Lampel
       given: Joseph
@@ -42,11 +45,13 @@ lamp:
       given: Theresa
     - family: Shamsie
       given: Jamal
-  isued: "2000"
+  issued: "2000"
   title: 
     main: Balancing Act
     sub: Learning from Organizing Practices in Cultural Industries
-  containerTitle: Organization Science
+  parent:
+    type: academic-journal
+    title: Organization Science
   volume: 11 
   issue: 3
   pages: 263-269
@@ -63,7 +68,7 @@ daum:
     name: Picador
     location: New York
 liu:
-  type: journal-article
+  type: article
   author:
     family: Liu
     given: Jui-Ch’i
@@ -71,26 +76,31 @@ liu:
   title:
     main: Beholding the Feminine Sublime
     sub: Lee Miller’s War Photography
-  containerTitle: Signs
+  parent:
+    title: Signs
+    type: academic-journal
   volume: 40
   issue: 2 # printed as 'no. 2'; not sure why
   pages: '308-19'
   doi: 10.1086/678242
 gund:
   # 15.48 exception:
-  type: journal-article
+  type: article
   author:
-  -  family: Gunderson
-     given: Alex R
+  - family: Gunderson
+    given: Alex R
   - family: Leal
     given: Manuel
   issued: '2015-05'
   title: Patterns of Thermal Constraint on Ectotherm Activity
-  containerTitle: American Naturalist
+  parent:
+    type: academic-journal
+    title: American Naturalist
   issue: 185 # no volume, so preface with label to disambiguate
   pages: 653–64
   doi: 10.1086/680849
 glass:
+  type: article
   author:
   - family: Glass
     given: Jennifer
@@ -100,19 +110,24 @@ glass:
   title:
     main: Red States, Blue States, and Divorce
     sub: Understanding the Impact of Conservative Protestantism on Regional Variation in Divorce Rates
-  containerTitle: American Journal of Sociology
+  parent:
+    type: academic-journal
+    title: American Journal of Sociology
   volume: 119
   issue: 4
   pages: 1002–46
   doi: 10.1086/674703
 meyer:
   # 15.47 exception (only an issue number, no volume):
+  type: article
   author: 
     family: Meyerovitch
     given: Eva
   issued: '1959'
   title: The Gnostic Manuscripts of Upper Egypt
-  containerTitle: Diogenes
+  parent:
+    type: academic-journal
+    title: Diogenes
   issue: 25
   pages: 84–117
 

--- a/processor/examples/ex1.bib.yaml
+++ b/processor/examples/ex1.bib.yaml
@@ -1,6 +1,6 @@
 ---
 un:
-  type: article
+  type: book
   title: Title 4
   author:
     name: United Nations
@@ -33,8 +33,11 @@ doe3:
     family: Doe
     given: Jane
   issued: '2020'
+  parent:
+    type: magazine
+    title: Pub title
 brown1:
-  type: article
+  type: book
   title: Title 5
   author: 
     name: Brown, John
@@ -47,7 +50,7 @@ lee1:
     given: Sarah
   issued: '2022'
 lee2:
-  type: article
+  type: document
   title: Title 7
   author: 
     family: Lee
@@ -61,7 +64,7 @@ miller1:
     given: David
   issued: '2018'
 miller2:
-  type: article
+  type: document
   title: Title 9
   author: 
     family: Miller
@@ -75,7 +78,7 @@ jones1:
     given: Michael
   issued: '2022'
 jones2:
-  type: article
+  type: book
   title: Title 11
   author: 
     family: Jones
@@ -89,7 +92,7 @@ smith2:
     given: John
   issued: '2020'
 smith3:
-  type: article
+  type: document
   title: Title 13
   author: 
     family: Smith
@@ -109,6 +112,9 @@ miller4:
     family: Miller
     given: Sarah
   issued: '2018'
+  parent:
+    type: academic-journal
+    title: XYZ Journal
 jones3:
   type: book
   title: Title 16
@@ -116,7 +122,7 @@ jones3:
     name: Jones, David
   issued: '2019'
 jones4:
-  type: article
+  type: book
   title: Title 17
   author: 
     name: Jones, David
@@ -128,7 +134,7 @@ brown2:
     name: Brown, Sarah
   issued: '2019'
 brown3:
-  type: article
+  type: document
   title: Title 19
   author:
     name: Brown, Sarah
@@ -141,7 +147,7 @@ lee3:
     given: David
   issued: '2006'
 lee4:
-  type: article
+  type: document
   title: Title 21
   author: 
     family: Lee
@@ -155,7 +161,7 @@ doe4:
     given: John
   issued: '2013'
 doe5:
-  type: article
+  type: book
   title: Title 23
   author: 
     family: Doe
@@ -169,7 +175,7 @@ smith4:
     given: Sarah
   issued: '2014'
 smith5:
-  type: article
+  type: book
   title: Title 25
   author: 
     family: Smith
@@ -183,7 +189,7 @@ miller5:
     given: John
   issued: '2016'
 miller6:
-  type: article
+  type: document
   title: Title 27
   author:
     family: Miller
@@ -199,7 +205,7 @@ jones5:
     given: Jane
   issued: '2018'
 jones6:
-  type: article
+  type: book
   title: Title 29
   author:
     family: Jones
@@ -213,7 +219,7 @@ brown4:
     given: David
   issued: '2021'
 brown5:
-  type: article
+  type: document
   title: Title 31
   # here we need a list
   author:
@@ -229,7 +235,7 @@ lee5:
     name: Lee, John
   issued: '2022'
 lee6:
-  type: article
+  type: document
   title: Title 33
   author: 
     family: Lee
@@ -243,7 +249,7 @@ doe6:
     given: Sarah
   issued: 'non-EDTF date'
 doe7:
-  type: article
+  type: document
   title: Title 35
   author: 
     family: Doe

--- a/processor/examples/ex1.bib.yaml
+++ b/processor/examples/ex1.bib.yaml
@@ -2,142 +2,192 @@
 un:
   type: article
   title: Title 4
-  author: ["United Nations"]
+  author:
+    name: United Nations
   issued: '2020'
 smith1:
   type: book
   title: Title 3
-  author: ["Smith, Sam"]
+  author:
+    family: Smith
+    given: John
   issued: '2023-10'
 doe1:
   type: book
   title: Title 2
-  author: ["Doe, Jane"]
+  author:
+    family: Doe
+    given: Jane
   issued: '2023-10'
 doe2:
   type: book
   title: Title 1
-  author: ["Doe, Jane"]
+  author:
+    family: Doe
+    given: Jane
   issued: '2020'
 doe3:
   type: article
   title: Title 0
-  author: ["Doe, Jane"]
+  author: 
+    family: Doe
+    given: Jane
   issued: '2020'
 brown1:
   type: article
   title: Title 5
-  author: ["Brown, John"]
+  author: 
+    name: Brown, John
   issued: '2021'
 lee1:
   type: book
   title: Title 6
-  author: ["Lee, Sarah"]
+  author:
+    family: Lee
+    given: Sarah
   issued: '2022'
 lee2:
   type: article
   title: Title 7
-  author: ["Lee, Sarah"]
+  author: 
+    family: Lee
+    given: Sarah
   issued: '2022'
 miller1:
   type: book
   title: Title 8
-  author: ["Miller, David"]
+  author: 
+    family: Miller
+    given: David
   issued: '2018'
 miller2:
   type: article
   title: Title 9
-  author: ["Miller, David"]
+  author: 
+    family: Miller
+    given: David
   issued: '2018'
 jones1:
   type: book
   title: Title 10
-  author: ["Jones, Michael"]
+  author:
+    family: Jones
+    given: Michael
   issued: '2022'
 jones2:
   type: article
   title: Title 11
-  author: ["Jones, Michael"]
+  author: 
+    family: Jones
+    given: Michael
   issued: '2022'
 smith2:
   type: book
   title: Title 12
-  author: ["Smith, John"]
+  author: 
+    family: Smith
+    given: John
   issued: '2020'
 smith3:
   type: article
   title: Title 13
-  author: ["Smith, John"]
+  author: 
+    family: Smith
+    given: John
   issued: '2020'
 miller3:
   type: book
   title: Title 14
-  author: ["Miller, Sarah"]
+  author: 
+    family: Miller
+    given: Sarah
   issued: '2017'
 miller4:
   type: article
   title: Title 15
-  author: ["Miller, Sarah"]
+  author: 
+    family: Miller
+    given: Sarah
   issued: '2018'
 jones3:
   type: book
   title: Title 16
-  author: ["Jones, David"]
+  author: 
+    name: Jones, David
   issued: '2019'
 jones4:
   type: article
   title: Title 17
-  author: ["Jones, David"]
+  author: 
+    name: Jones, David
   issued: '2019'
 brown2:
   type: book
   title: Title 18
-  author: ["Brown, Sarah"]
+  author: 
+    name: Brown, Sarah
   issued: '2019'
 brown3:
   type: article
   title: Title 19
-  author: ["Brown, Sarah"]
+  author:
+    name: Brown, Sarah
   issued: '2019'
 lee3:
   type: book
   title: Title 20
-  author: ["Lee, David"]
+  author: 
+    family: Lee
+    given: David
   issued: '2006'
 lee4:
   type: article
   title: Title 21
-  author: ["Lee, David"]
+  author: 
+    family: Lee
+    given: David
   issued: '2006'
 doe4:
   type: book
   title: Title 22
-  author: ["Doe, John"]
+  author: 
+    family: Doe
+    given: John
   issued: '2013'
 doe5:
   type: article
   title: Title 23
-  author: ["Doe, John"]
+  author: 
+    family: Doe
+    given: John
   issued: '2013'
 smith4:
   type: book
   title: Title 24
-  author: ["Smith, Sarah"]
+  author: 
+    family: Smith
+    given: Sarah
   issued: '2014'
 smith5:
   type: article
   title: Title 25
-  author: ["Smith, Sarah"]
+  author: 
+    family: Smith
+    given: Sarah
   issued: '2015'
 miller5:
   type: book
   title: Title 26
-  author: ["Miller, John"]
+  author: 
+    family: Miller
+    given: John
   issued: '2016'
 miller6:
   type: article
   title: Title 27
-  author: ["Miller, John"]
+  author:
+    family: Miller
+    given: John
   issued: '2032'
 jones5:
   type: book
@@ -145,48 +195,57 @@ jones5:
   # for single author pieces, there's no point in a list
   # but if we need structured data, as we do with Western names,let's structure it
   author:
-    familyName: Doe
-    givenName: Jane
+    family: Doe
+    given: Jane
   issued: '2018'
 jones6:
   type: article
   title: Title 29
   author:
-    familyName: Jones
-    givenName: Sarah
+    family: Jones
+    given: Sarah
   issued: '2018'
 brown4:
   type: book
   title: Title 30
-  author: ["Brown, David"]
+  author: 
+    family: Brown
+    given: David
   issued: '2021'
 brown5:
   type: article
   title: Title 31
   # here we need a list
   author:
-    - familyName: Brown
-      givenName: David
-    - familyName: Lee
-      givenName: Jane
+    - family: Brown
+      given: David
+    - family: Lee
+      given: Jane
   issued: '2021'
 lee5:
   type: book
   title: Title 32
-  author: ["Lee, John"]
+  author: 
+    name: Lee, John
   issued: '2022'
 lee6:
   type: article
   title: Title 33
-  author: ["Lee, John"]
+  author: 
+    family: Lee
+    given: John
   issued: '2022'
 doe6:
   type: book
   title: Title 34
-  author: ["Doe, Sarah"]
+  author:
+    family: Doe
+    given: Sarah
   issued: 'non-EDTF date'
 doe7:
   type: article
   title: Title 35
-  author: ["Doe, Sarah"]
+  author: 
+    family: Doe
+    given: Sarah
   issued: '2009'

--- a/processor/tests/processor_test.rs
+++ b/processor/tests/processor_test.rs
@@ -7,13 +7,18 @@ mod tests {
     fn sorts_references() {
         let style = style::Style::from_file("examples/style.csl.yaml");
         let locale = style::locale::Locale::from_file("locales/locale-en.yaml");
-        let bibliography = bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
+        let bibliography =
+            bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
         let citations: Vec<Citation> = Vec::new();
-        let processor = csln_processor::Processor::new(style, bibliography, citations, locale);
+        let processor =
+            csln_processor::Processor::new(style, bibliography, citations, locale);
         let refs = processor.get_references();
         let sorted_refs = processor.sort_references(refs);
         assert_eq!(sorted_refs.len(), 36);
-        assert_eq!(sorted_refs.last().unwrap().title.as_ref().unwrap().to_string(), "Title 4");
+        assert_eq!(
+            sorted_refs.last().unwrap().title().unwrap().to_string(),
+            "Title 4"
+        );
     }
 
     #[test]
@@ -21,8 +26,10 @@ mod tests {
         let style = style::Style::from_file("examples/style.csl.yaml");
         let locale = style::locale::Locale::from_file("locales/locale-en.yaml");
         let citations: Vec<Citation> = Vec::new();
-        let bibliography = bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
-        let processor = csln_processor::Processor::new(style, bibliography, citations, locale);
+        let bibliography =
+            bibliography::InputBibliography::from_file("examples/ex1.bib.yaml");
+        let processor =
+            csln_processor::Processor::new(style, bibliography, citations, locale);
         let proc_hints = processor.get_proc_hints();
         assert_eq!(proc_hints["doe7"].group_index, 1);
         assert_eq!(proc_hints["doe7"].group_length, 1);

--- a/style/src/lib.rs
+++ b/style/src/lib.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 
-pub mod options;
 pub mod locale;
+pub mod options;
 use options::Config;
 
 pub mod template;

--- a/style/src/locale.rs
+++ b/style/src/locale.rs
@@ -6,14 +6,15 @@ use std::fs;
 #[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 pub struct Locale {
     pub locale: String,
-   // pub options: LocaleOptions,
+    // pub options: LocaleOptions,
     pub dates: DateTerms,
     //pub contributors: ContributorTerms,
 }
 
 impl Locale {
     pub fn from_file(locale_path: &str) -> Locale {
-        let contents = fs::read_to_string(locale_path).expect("Failed to read locale file");
+        let contents =
+            fs::read_to_string(locale_path).expect("Failed to read locale file");
         if locale_path.ends_with(".json") {
             serde_json::from_str(&contents).expect("Failed to parse JSON")
         } else if locale_path.ends_with(".yaml") || locale_path.ends_with(".yml") {

--- a/style/src/options.rs
+++ b/style/src/options.rs
@@ -16,7 +16,7 @@ SPDX-FileCopyrightText: © 2023 Bruce D'Arcus
 //!
 //! ## Style Options
 //!
-//! The [`StyleOptions`] struct defines the configuration groups and options available in CSLN styles.
+//! The [`Config`] struct defines the configuration groups and options available in CSLN styles.
 //!
 //! ## Status
 //!
@@ -65,35 +65,21 @@ pub struct ProcessingCustom {
 impl Processing {
     pub fn config(&self) -> ProcessingCustom {
         match self {
-            Processing::AuthorDate => {
-                ProcessingCustom {
-                    sort: Some(Sort {
-                        shorten_names: false,
-                        render_substitutions: false,
-                        template: vec![
-                            SortSpec { key: SortKey::Author, ascending: true },
-                            SortSpec { key: SortKey::Year, ascending: true },
-                        ],
-                    }),
-                    group: Some(Group {
-                        template: vec![
-                            SortKey::Author,
-                            SortKey::Year,
-                        ],
-                    }),
-                    disambiguate: Some(Disambiguation {
-                        names: true,
-                        year_suffix: true,
-                    }),
-                }
+            Processing::AuthorDate => ProcessingCustom {
+                sort: Some(Sort {
+                    shorten_names: false,
+                    render_substitutions: false,
+                    template: vec![
+                        SortSpec { key: SortKey::Author, ascending: true },
+                        SortSpec { key: SortKey::Year, ascending: true },
+                    ],
+                }),
+                group: Some(Group { template: vec![SortKey::Author, SortKey::Year] }),
+                disambiguate: Some(Disambiguation { names: true, year_suffix: true }),
             },
             Processing::Numeric => {
-                ProcessingCustom {
-                    sort: None,
-                    group: None,
-                    disambiguate: None,
-                }
-            },
+                ProcessingCustom { sort: None, group: None, disambiguate: None }
+            }
             Processing::Custom(custom) => custom.clone(),
         }
     }


### PR DESCRIPTION
Split input model into structural classes, much like the very first CSL implementation.

Closes: #93

------------

TODO:

1. [X] add identifiers
2. [X] add a `NumOrStr` type for use in locators, etc.

This is a pretty major internal change.

Like the very first CSL implementation, almost 20 years ago, this splits `InputReference` into different classes. A `Book` type, for example, is a `Monograph`, while a `JournalArticle` is a `SerialComponent`.

```yaml
type: article
title: Article title
  parent:
    type: academic-journal
    title: Journal title
```

Aside: I want to allow parents to be referenced by citekey, but I haven't figured out how to do that technically. My suspicion is it will take another major internal change; changing bibliography to be an `IndexMap` and writing some custom deserialization code. So it's not worth the hassle ATM.

This also addresses some other internal issues I was unhappy with.

For example, the `render` traits now return `Option<String>`, and surrounding code is updated to better handle missing data.