### PR TITLE
string output, substitution

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     let citations: Vec<Citation> = Vec::new();
     let locale = csln::style::locale::Locale::from_file(&opts.locale);
     let processor: Processor = Processor::new(style, bibliography, citations, locale);
-    let rendered_refs = processor.render_references();
+    let rendered_refs = processor.process_references();
     println!("{}", refs_to_string(rendered_refs));
     //println!("{}", serde_json::to_string_pretty(&rendered_refs).unwrap());
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use csln::bibliography::HasFile;
 use csln::bibliography::InputBibliography as Bibliography;
 use csln::citation::Citation;
 use csln::style::Style;
-use processor::Processor;
+use processor::{refs_to_string, Processor};
 
 #[derive(Parser, Default, Debug)]
 #[clap(author = "Bruce D'Arcus", version, about = "A CLI for CSLN")]
@@ -27,5 +27,6 @@ fn main() {
     let locale = csln::style::locale::Locale::from_file(&opts.locale);
     let processor: Processor = Processor::new(style, bibliography, citations, locale);
     let rendered_refs = processor.render_references();
-    println!("{}", serde_json::to_string_pretty(&rendered_refs).unwrap());
+    println!("{}", refs_to_string(rendered_refs));
+    //println!("{}", serde_json::to_string_pretty(&rendered_refs).unwrap());
 }

--- a/csln/src/bibliography/reference.rs
+++ b/csln/src/bibliography/reference.rs
@@ -110,6 +110,7 @@ impl InputReference {
             // REVIEW: return string instead?
             InputReference::Monograph(r) => r.publisher.clone(),
             InputReference::MonographComponent(r) => r.parent.publisher.clone(),
+            InputReference::Collection(r) => r.publisher.clone(),
             _ => None,
         }
     }

--- a/csln/src/bibliography/reference.rs
+++ b/csln/src/bibliography/reference.rs
@@ -201,7 +201,7 @@ pub struct Collection {
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
-    pub issn: Option<String>,
+    pub isbn: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]

--- a/csln/src/style/template.rs
+++ b/csln/src/style/template.rs
@@ -23,7 +23,7 @@ pub enum WrapPunctuation {
 }
 
 /// The Template component model. Each item is for a specific datatype.
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum TemplateComponent {
@@ -46,16 +46,24 @@ impl TemplateComponent {
             TemplateComponent::SimpleString(s) => s.rendering.clone(),
         }
     }
+
+    // TODO do I need this?
+    pub fn is_author(&self) -> bool {
+        match self {
+            TemplateComponent::Contributor(c) => c.contributor == ContributorRole::Author,
+            _ => false,
+        }
+    }
 }
 
 /// A simple string component, to render a string variable.
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 pub struct TemplateSimpleString {
     pub variable: Variables,
     pub rendering: Option<Rendering>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Variables {
     // TODO: add more variables
@@ -65,14 +73,14 @@ pub enum Variables {
 }
 
 /// A number component, to render a number.
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 pub struct TemplateNumber {
     pub number: Numbers,
     pub form: Option<NumberForm>,
     pub rendering: Option<Rendering>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Numbers {
     Volume,
@@ -80,7 +88,7 @@ pub enum Numbers {
     Pages,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum NumberForm {
     #[default]
@@ -89,7 +97,7 @@ pub enum NumberForm {
 }
 
 /// To render is a list of more than one item; primarily to enable use of a delimiter to join the items.
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 pub struct TemplateList {
     pub delimiter: Option<DelimiterPunctuation>,
     pub prefix: Option<String>,
@@ -99,7 +107,7 @@ pub struct TemplateList {
 }
 
 /// The punctuation to use as a delimiter between items in a list.
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum DelimiterPunctuation {
     Comma,
@@ -116,21 +124,21 @@ pub enum DelimiterPunctuation {
 
 /// A contributor component, to render a list of contributors.
 // TODO incomplete
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 pub struct TemplateContributor {
     pub contributor: ContributorRole,
     pub form: ContributorForm,
     pub rendering: Option<Rendering>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum ContributorForm {
     Long,
     Short,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum ContributorRole {
     Author,
@@ -147,14 +155,14 @@ pub enum ContributorRole {
 }
 
 /// A date component, to render a date.
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 pub struct TemplateDate {
     pub date: Dates,
     pub form: DateForm,
     pub rendering: Option<Rendering>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Dates {
     Issued,
@@ -162,7 +170,7 @@ pub enum Dates {
     OriginalPublished,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum DateForm {
     Year,
@@ -172,14 +180,14 @@ pub enum DateForm {
 }
 
 /// A title component, to render a title.
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 pub struct TemplateTitle {
     pub title: Titles,
     pub form: Option<TitleForm>,
     pub rendering: Option<Rendering>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum Titles {
@@ -191,7 +199,7 @@ pub enum Titles {
     ParentSerial,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TitleForm {
     Short,

--- a/processor/benches/proc_bench.rs
+++ b/processor/benches/proc_bench.rs
@@ -25,7 +25,7 @@ fn proc_benchmark(c: &mut Criterion) {
     });
     c.bench_function("rendering references", |b| {
         b.iter(|| {
-            processor.render_references();
+            processor.process_references();
         })
     });
 }

--- a/processor/examples/chicago.bib.yaml
+++ b/processor/examples/chicago.bib.yaml
@@ -56,7 +56,7 @@ lamp:
   issue: 3
   pages: 263-269
 daum:
-  type: book
+  type: edited-book
   editor:
     family: Daum
     given: Meghan

--- a/processor/examples/style.csl.yaml
+++ b/processor/examples/style.csl.yaml
@@ -39,6 +39,8 @@ bibliography:
       rendering: # not a fan of this
         wrap: parentheses
     - title: primary
+    - contributor: editor
+      form: long
     - title: parent-monograph
       prefix: In 
       emph: true
@@ -47,6 +49,6 @@ bibliography:
       form: month-day
     - number: volume
     - variable: doi
-    - contributor: publisher
+    - contributor: publisher # location?
       form: long # make optional, with default?
       delimiter: colon # scope? delimiter vs item-delimiter?

--- a/processor/examples/style.csl.yaml
+++ b/processor/examples/style.csl.yaml
@@ -36,6 +36,8 @@ bibliography:
       form: long
     - date: issued
       form: year
+      rendering: # not a fan of this
+        wrap: parentheses
     - title: primary
     - title: parent-monograph
       prefix: In 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -35,6 +35,23 @@ The processor takes a style, a bibliography, and a locale, and renders the outpu
 The primary target is a JSON AST, represented by the ProcTemplateComponent struct.
  */
 
+// TODO: This will need to be generalized later. See:
+// https://github.com/bdarcus/csln/issues/105
+pub fn refs_to_string(proc_templates: Vec<ProcTemplate>) -> String {
+    proc_templates
+        .iter()
+        .map(|proc_template| {
+            proc_template
+                .iter()
+                .map(|proc_template_component| proc_template_component.to_string())
+                .collect::<Vec<String>>()
+                .join(". ")
+                + "."
+        })
+        .collect::<Vec<String>>()
+        .join("\n\n")
+}
+
 /// The processor struct, which takes a style, a bibliography, and a locale, and renders the output.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Processor {

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -185,8 +185,8 @@ pub trait Render<T> {
     ) -> String;
 }
 
-pub trait RenderComponent {
-    fn render(
+pub trait ComponentValue {
+    fn value(
         &self,
         reference: &InputReference,
         hints: &ProcHints,
@@ -194,8 +194,8 @@ pub trait RenderComponent {
     ) -> Option<String>;
 }
 
-impl RenderComponent for TemplateComponent {
-    fn render(
+impl ComponentValue for TemplateComponent {
+    fn value(
         &self,
         reference: &InputReference,
         hints: &ProcHints,
@@ -204,15 +204,15 @@ impl RenderComponent for TemplateComponent {
     ) -> Option<String> {
         match self {
             TemplateComponent::Title(title) => {
-                Some(title.render(reference, hints, options).unwrap_or_default())
+                Some(title.value(reference, hints, options).unwrap_or_default())
             }
             TemplateComponent::Contributor(contributor) => {
-                contributor.render(reference, hints, options)
+                contributor.value(reference, hints, options)
             }
-            TemplateComponent::Date(date) => date.render(reference, hints, options),
-            TemplateComponent::Number(number) => number.render(reference, hints, options),
+            TemplateComponent::Date(date) => date.value(reference, hints, options),
+            TemplateComponent::Number(number) => number.value(reference, hints, options),
             TemplateComponent::SimpleString(string) => {
-                string.render(reference, hints, options)
+                string.value(reference, hints, options)
             }
             TemplateComponent::List(_list) => todo!(),
             _ => None,
@@ -220,8 +220,8 @@ impl RenderComponent for TemplateComponent {
     }
 }
 
-impl RenderComponent for TemplateNumber {
-    fn render(
+impl ComponentValue for TemplateNumber {
+    fn value(
         &self,
         reference: &InputReference,
         _hints: &ProcHints,
@@ -254,8 +254,8 @@ impl RenderComponent for TemplateNumber {
     }
 }
 
-impl RenderComponent for TemplateSimpleString {
-    fn render(
+impl ComponentValue for TemplateSimpleString {
+    fn value(
         &self,
         reference: &InputReference,
         _hints: &ProcHints,
@@ -287,8 +287,8 @@ impl RenderComponent for TemplateSimpleString {
     }
 }
 
-impl RenderComponent for TemplateTitle {
-    fn render(
+impl ComponentValue for TemplateTitle {
+    fn value(
         &self,
         reference: &InputReference,
         _hints: &ProcHints,
@@ -330,8 +330,8 @@ impl RenderComponent for TemplateTitle {
     }
 }
 
-impl RenderComponent for TemplateContributor {
-    fn render(
+impl ComponentValue for TemplateContributor {
+    fn value(
         &self,
         reference: &InputReference,
         _hints: &ProcHints,
@@ -361,8 +361,8 @@ impl RenderComponent for TemplateContributor {
     }
 }
 
-impl RenderComponent for TemplateDate {
-    fn render(
+impl ComponentValue for TemplateDate {
+    fn value(
         &self,
         reference: &InputReference,
         hints: &ProcHints,
@@ -485,7 +485,7 @@ impl Processor {
         let hint: ProcHints =
             hints.get(&reference_id.unwrap()).cloned().unwrap_or_default();
         let options = self.get_render_options(self.style.clone(), self.locale.clone());
-        let value = component.render(reference, &hint, &options)?;
+        let value = component.value(reference, &hint, &options)?;
         let template_component = component.clone();
         if !value.is_empty() {
             Some(ProcTemplateComponent { template_component, value })

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -63,7 +63,7 @@ pub struct ProcTemplateComponent {
 }
 
 #[test]
-fn test_proc_template_component() {
+fn render_proc_template_component() {
     use csln::style::template::Rendering;
     let template_component = TemplateComponent::SimpleString(TemplateSimpleString {
         variable: Variables::Doi,


### PR DESCRIPTION
I can't figure out how I want to do #105, so just added a basic `refs_to_string` function for now so I have some final rendering I can work with.

## TODO

#23:

- [X]  basic substitution
- [X] incorporate substitution into sorting, grouping; probably need a common substitution method
- [X] subsequent suppression of substituted values

I may defer these:

- [ ] incorporation of role for editors, translators (though this is broader than this feature, so should be in a separate commit
- [ ] convert chicago style example to a compliant file
- [ ] confirm contributor code and style details are correct
- [ ] delimiters in general?

On #105, I was partly getting confused by the symbol names around "render", and so have split the traits and methods into instead "process" (converting input into `ProcTemplateComponent` items and vectors) and "value" (the strings using in the process output).

Not sure this is ideal ATM, or if I even really need traits for these, but it makes sense conceptually. And since I did make some progress here, and may finish it before merging, so I don't have to revert commits later.

## Notes

### Tracking author substitutions

I need to add some way to track author substitution, so can know what to do in citations and bibliography respectively. Initially I was adding a variable to the method, but I think maybe it's better to add one to the `Processor`; maybe to `ProcHints` ?

So when processing an editor, translator or title (the only substitution options ATM), can just check that, and forego processing if it's the same?

Either way, I think I need to add a `author_substitute` method.

### Values

Right now, a `ProcTemplateComponent` holds a `value` string, which is created as part of that process, and incorporates formatting specs in the `TemplateComponent`.

But I suppose another approach would be to transform the `InputReference` into a collection of different types of value strings before they get to the templates; something like:

```rust
struct formattedReference {
  contributors: HashMap<ContributorRole, ContributorStrings>,
  ...
}

struct ContributorStrings {
  long: String,
  short: String,
  // affixes?
}
```

Could maybe even add a Trait for it?

-----------------

Here's the current plain text output from the chicago bib example:

------------------------------

Tom Bissell. (2011). Extra Lives: Why Video Games Matter. Vintage Books.

Meghan Daum. (2015). Selfish, Shallow, and Self-Absorbed: Sixteen Writers on the Decision Not to Have Kids. Picador.

Glass, Jennifer, Levchak, Philip. (2014). Red States, Blue States, and Divorce: Understanding the Impact of Conservative Protestantism on Regional Variation in Divorce Rates. American Journal of Sociology. 119. 10.1086/674703.

Gunderson, Alex R, Leal, Manuel. (2015). Patterns of Thermal Constraint on Ectotherm Activity. American Naturalist. May 1. 10.1086/680849.

Michael Hutter. (2011). Infinite Surprises: Value in the Creative Industries. The Worth of Goods: Valuation and Pricing in the Economy. Oxford University Press.

Lampel, Joseph, Lant, Theresa, Shamsie, Jamal. (2000). Balancing Act: Learning from Organizing Practices in Cultural Industries. Organization Science. 11.

Jui-Ch’i Liu. (2015). Beholding the Feminine Sublime: Lee Miller’s War Photography. Signs. 40. 10.1086/678242.

Eva Meyerovitch. (1959). The Gnostic Manuscripts of Upper Egypt. Diogenes.


