### PR TITLE
Editor fix

### DIFF
--- a/csln/src/bibliography/reference.rs
+++ b/csln/src/bibliography/reference.rs
@@ -49,7 +49,7 @@ pub enum InputReference {
     Monograph(Monograph),
     /// A component of a larger Monography, such as a chapter in a book.
     /// The parent monograph is referenced by its ID.
-    MonographComponent(MonographComponent),
+    CollectionComponent(CollectionComponent),
     /// A componet of a larger serial publication; for example a journal or newspaper article.
     /// The parent serial is referenced by its ID.
     SerialComponent(SerialComponent),
@@ -65,7 +65,7 @@ impl InputReference {
     pub fn id(&self) -> Option<RefID> {
         match self {
             InputReference::Monograph(r) => r.id.clone(),
-            InputReference::MonographComponent(r) => r.id.clone(),
+            InputReference::CollectionComponent(r) => r.id.clone(),
             InputReference::SerialComponent(r) => r.id.clone(),
             InputReference::Collection(r) => r.id.clone(),
         }
@@ -81,7 +81,7 @@ impl InputReference {
             InputReference::Monograph(r) => {
                 Some((r.author.clone()?, ContributorRole::Author))
             }
-            InputReference::MonographComponent(r) => {
+            InputReference::CollectionComponent(r) => {
                 Some((r.author.clone()?, ContributorRole::Author))
             }
             InputReference::SerialComponent(r) => {
@@ -96,6 +96,7 @@ impl InputReference {
         match self {
             // REVIEW: return string instead?
             InputReference::Collection(r) => r.editor.clone(),
+            InputReference::CollectionComponent(r) => r.parent.editor.clone(),
             _ => None,
         }
     }
@@ -106,7 +107,7 @@ impl InputReference {
         match self {
             // REVIEW: return string instead?
             InputReference::Monograph(r) => r.translator.clone(),
-            InputReference::MonographComponent(r) => r.translator.clone(),
+            InputReference::CollectionComponent(r) => r.translator.clone(),
             InputReference::SerialComponent(r) => r.translator.clone(),
             InputReference::Collection(r) => r.translator.clone(),
         }
@@ -118,7 +119,7 @@ impl InputReference {
         match self {
             // REVIEW: return string instead?
             InputReference::Monograph(r) => r.publisher.clone(),
-            InputReference::MonographComponent(r) => r.parent.publisher.clone(),
+            InputReference::CollectionComponent(r) => r.parent.publisher.clone(),
             InputReference::Collection(r) => r.publisher.clone(),
             _ => None,
         }
@@ -129,7 +130,7 @@ impl InputReference {
     pub fn title(&self) -> Option<Title> {
         match self {
             InputReference::Monograph(r) => Some(r.title.clone()),
-            InputReference::MonographComponent(r) => r.title.clone(),
+            InputReference::CollectionComponent(r) => r.title.clone(),
             InputReference::SerialComponent(r) => r.title.clone(),
             InputReference::Collection(r) => r.title.clone(),
         }
@@ -140,7 +141,7 @@ impl InputReference {
     pub fn issued(&self) -> Option<EdtfString> {
         match self {
             InputReference::Monograph(r) => Some(r.issued.clone()),
-            InputReference::MonographComponent(r) => Some(r.issued.clone()),
+            InputReference::CollectionComponent(r) => Some(r.issued.clone()),
             InputReference::SerialComponent(r) => Some(r.issued.clone()),
             InputReference::Collection(r) => Some(r.issued.clone()),
         }
@@ -149,7 +150,7 @@ impl InputReference {
     pub fn set_id(&mut self, id: String) {
         match self {
             InputReference::Monograph(monograph) => monograph.id = Some(id),
-            InputReference::MonographComponent(monograph_component) => {
+            InputReference::CollectionComponent(monograph_component) => {
                 monograph_component.id = Some(id)
             }
             InputReference::SerialComponent(serial_component) => {
@@ -305,7 +306,7 @@ pub enum MonographType {
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 /// A component of a larger Monography, such as a chapter in a book.
 /// The parent monograph is referenced by its ID.
-pub struct MonographComponent {
+pub struct CollectionComponent {
     pub id: Option<RefID>,
     pub r#type: MonographComponentType,
     pub title: Option<Title>,
@@ -314,7 +315,7 @@ pub struct MonographComponent {
     pub issued: EdtfString,
     /// The parent work, as either a Monograph.
     // I would like to allow this to be either a Monograph or a RefID, but I can't figure out how to do that.
-    pub parent: Monograph,
+    pub parent: Collection,
     pub pages: Option<NumOrStr>,
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,

--- a/csln/src/bibliography/reference.rs
+++ b/csln/src/bibliography/reference.rs
@@ -30,7 +30,6 @@ SPDX-FileCopyrightText: © 2023 Bruce D'Arcus
 
 use crate::style::locale::Locale;
 use crate::style::options::{AndOptions, AndOtherOptions, DisplayAsSort};
-use crate::style::template::ContributorRole;
 use crate::style::{locale::MonthList, options::Config};
 use edtf::level_1::Edtf;
 use fmt::Display;
@@ -73,20 +72,12 @@ impl InputReference {
 
     /// Return the author.
     /// If the reference does not have an author, return None.
-    pub fn author(&self) -> Option<(Contributor, ContributorRole)> {
+    pub fn author(&self) -> Option<Contributor> {
         match self {
-            InputReference::Collection(r) => {
-                Some((r.editor.clone()?, ContributorRole::Editor))
-            }
-            InputReference::Monograph(r) => {
-                Some((r.author.clone()?, ContributorRole::Author))
-            }
-            InputReference::CollectionComponent(r) => {
-                Some((r.author.clone()?, ContributorRole::Author))
-            }
-            InputReference::SerialComponent(r) => {
-                Some((r.author.clone()?, ContributorRole::Author))
-            } // TODO: so this isn't really using the substitution config
+            InputReference::Monograph(r) => Some(r.author.clone()?),
+            InputReference::CollectionComponent(r) => Some(r.author.clone()?),
+            InputReference::SerialComponent(r) => Some(r.author.clone()?),
+            _ => None,
         }
     }
 

--- a/processor/examples/chicago.bib.yaml
+++ b/processor/examples/chicago.bib.yaml
@@ -22,7 +22,7 @@ hutt:
     main: Infinite Surprises
     sub: Value in the Creative Industries
   parent:
-    type: book
+    type: edited-book
     issued: "2011" # currerntly required in both places
     title: 
       main: The Worth of Goods

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -270,7 +270,7 @@ impl ComponentValues for TemplateNumber {
                 InputReference::SerialComponent(serial_component) => {
                     Some(serial_component.pages.as_ref()?.to_string())
                 }
-                InputReference::MonographComponent(monograph_component) => {
+                InputReference::CollectionComponent(monograph_component) => {
                     Some(monograph_component.pages.as_ref()?.to_string())
                 }
                 _ => None,
@@ -296,7 +296,7 @@ impl ComponentValues for TemplateSimpleString {
                 InputReference::SerialComponent(serial_component) => {
                     Some(serial_component.doi.as_ref()?.to_string())
                 }
-                InputReference::MonographComponent(monograph_component) => {
+                InputReference::CollectionComponent(monograph_component) => {
                     Some(monograph_component.doi.as_ref()?.to_string())
                 }
                 _ => None,
@@ -326,9 +326,10 @@ impl ComponentValues for TemplateTitle {
     ) -> Option<ProcValues> {
         let value = match &self.title {
             Titles::ParentMonograph => {
-                if let InputReference::MonographComponent(monograph_component) = reference
+                if let InputReference::CollectionComponent(collection_component) =
+                    reference
                 {
-                    Some(monograph_component.parent.title.to_string())
+                    Some(collection_component.parent.title.as_ref()?.to_string())
                 } else {
                     None
                 }
@@ -345,7 +346,7 @@ impl ComponentValues for TemplateTitle {
                 InputReference::Collection(collection) => {
                     Some(collection.title.as_ref()?.to_string())
                 }
-                InputReference::MonographComponent(monograph_component) => {
+                InputReference::CollectionComponent(monograph_component) => {
                     Some(monograph_component.title.as_ref()?.to_string())
                 }
                 InputReference::SerialComponent(serial_component) => {
@@ -635,9 +636,9 @@ impl Processor {
                     input_reference.set_id(key.clone());
                     input_reference
                 }
-                InputReference::MonographComponent(monograph_component) => {
+                InputReference::CollectionComponent(collection_component) => {
                     let mut input_reference =
-                        InputReference::MonographComponent(monograph_component.clone());
+                        InputReference::CollectionComponent(collection_component.clone());
                     input_reference.set_id(key.clone());
                     input_reference
                 }
@@ -756,8 +757,8 @@ impl Processor {
                         };
                         let ref_id = match reference {
                             InputReference::Monograph(monograph) => monograph.id.clone(),
-                            InputReference::MonographComponent(monograph_component) => {
-                                monograph_component.id.clone()
+                            InputReference::CollectionComponent(collection_component) => {
+                                collection_component.id.clone()
                             }
                             InputReference::SerialComponent(serial_component) => {
                                 serial_component.id.clone()


### PR DESCRIPTION
#121 is driving me crazy, but I've at least narrowed the problem to the `suppress_component` method, and specifically to the logic for editors.

-----------------------

I think fixing this may require reverting an earlier refactor.

The `reference.author()` method should only return an author, and the substitution should happen somewhere else, and explicitly.

It could be I move `get_author_substitute` to `InputReference`, which seems the natural place to put it. But that likely means it would be hard-coded?

Or maybe not; could return a hash table of the substitution options, and let the processor select the correct one based on the style config?