### PR TITLE
feat: add citation support

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
-use csln::bibliography::HasFile;
 use csln::bibliography::InputBibliography as Bibliography;
-use csln::citation::Citation;
+use csln::citation::Citations;
 use csln::style::Style;
+use csln::HasFile;
 use processor::Processor;
 
 #[derive(Parser, Default, Debug)]
@@ -15,6 +15,9 @@ pub struct Opts {
     /// The path to the CSLN bibliography file
     bibliography: String,
     #[clap(short, long)]
+    /// The optional path to the CSLN citation file
+    citation: Option<String>,
+    #[clap(short, long)]
     /// The path to the CSLN locale file
     locale: String,
 }
@@ -23,7 +26,8 @@ fn main() {
     let opts = Opts::parse();
     let style: Style = Style::from_file(&opts.style);
     let bibliography: Bibliography = Bibliography::from_file(&opts.bibliography);
-    let citations: Vec<Citation> = Vec::new();
+    // TODO load citations from file
+    let citations: Citations = Citations::from_file(&opts.citation.unwrap_or_default());
     let locale = csln::style::locale::Locale::from_file(&opts.locale);
     let processor: Processor = Processor::new(style, bibliography, citations, locale);
     let rendered_refs = processor.process_references();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use csln::bibliography::HasFile;
 use csln::bibliography::InputBibliography as Bibliography;
 use csln::citation::Citation;
 use csln::style::Style;
-use processor::{refs_to_string, Processor};
+use processor::Processor;
 
 #[derive(Parser, Default, Debug)]
 #[clap(author = "Bruce D'Arcus", version, about = "A CLI for CSLN")]
@@ -27,6 +27,6 @@ fn main() {
     let locale = csln::style::locale::Locale::from_file(&opts.locale);
     let processor: Processor = Processor::new(style, bibliography, citations, locale);
     let rendered_refs = processor.process_references();
-    println!("{}", refs_to_string(rendered_refs));
-    //println!("{}", serde_json::to_string_pretty(&rendered_refs).unwrap());
+    //println!("{}", refs_to_string(rendered_refs));
+    println!("{}", serde_json::to_string_pretty(&rendered_refs).unwrap());
 }

--- a/csln/src/bibliography/mod.rs
+++ b/csln/src/bibliography/mod.rs
@@ -1,3 +1,4 @@
+use crate::HasFile;
 use std::collections::HashMap;
 use std::fs;
 
@@ -6,11 +7,6 @@ pub use reference::InputReference;
 
 /// A bibliography is a collection of references.
 pub type InputBibliography = HashMap<String, InputReference>;
-
-// REVIEW move this to a core traits.rs module?
-pub trait HasFile {
-    fn from_file(path: &str) -> Self;
-}
 
 impl HasFile for InputBibliography {
     /// Load and parse a YAML or JSON bibliography file.

--- a/csln/src/citation/mod.rs
+++ b/csln/src/citation/mod.rs
@@ -39,7 +39,7 @@ data CitationItem a =
   , citationItemData           :: Maybe (Reference a)
   } */
 
-#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct Citation {
     pub note_number: Option<i32>,
     pub id: Option<String>,
@@ -54,7 +54,7 @@ pub struct Citation {
     pub suffix: Option<String>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum CitationModeType {
     /// Places the author inline in the text; also known as "narrative" or "in text" citations.
@@ -64,7 +64,7 @@ pub enum CitationModeType {
     NonIntegral,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CitationItem {
     pub label: Option<String>,
@@ -78,7 +78,7 @@ pub struct CitationItem {
 
 #[allow(clippy::large_enum_variant)] // REVIEW is this a problem?
 /// A key-value object, or a string.
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum Locator {
     KeyValue(LocatorKeyValue),
@@ -87,7 +87,7 @@ pub enum Locator {
 
 pub type LocatorKeyValue = (LocatorTerm, String);
 
-#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum LocatorTerm {
     Book,

--- a/csln/src/citation/mod.rs
+++ b/csln/src/citation/mod.rs
@@ -6,16 +6,34 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct CitationList(pub Vec<Citation>);
 
+/* data Citation a =
+  Citation { citationId         :: Maybe Text
+           , citationNoteNumber :: Maybe Int
+           , citationItems      :: [CitationItem a] }
+
+data CitationItem a =
+  CitationItem
+  { citationItemId             :: ItemId
+  , citationItemLabel          :: Maybe Text
+  , citationItemLocator        :: Maybe Text
+  , citationItemType           :: CitationItemType
+  , citationItemPrefix         :: Maybe a
+  , citationItemSuffix         :: Maybe a
+  , citationItemData           :: Maybe (Reference a)
+  } */
+
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct Citation {
+    pub note_number: Option<i32>,
+    pub id: Option<String>,
     /// Local citation rendering option; aka command or style.
-    /// Both are more general than author-date styles, and can apply to any citation style.
+    /// These are more general than author-date styles, and can apply to any citation style.
     pub mode: CitationModeType,
     /// The string that prefaces a list of citation references.
     pub prefix: Option<String>,
-    /// A vector of CitatoinReference objects.
-    pub references: Vec<CitationReference>,
-    /// A string that follows a list of citation references.
+    /// A vector of CitationItem objects.
+    pub citation_items: Vec<CitationItem>,
+    /// A string that follows a list of qcitation references.
     pub suffix: Option<String>,
 }
 
@@ -31,7 +49,8 @@ pub enum CitationModeType {
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct CitationReference {
+pub struct CitationItem {
+    pub label: Option<String>,
     /// A string that prefaces the citation reference.
     pub prefix: Option<String>,
     /// The unique identifier token for the citation reference.

--- a/csln/src/citation/mod.rs
+++ b/csln/src/citation/mod.rs
@@ -1,6 +1,23 @@
-// originally converted from the typescript source with quicktype
+use crate::HasFile;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::fs;
+
+impl HasFile for Citations {
+    fn from_file(citations_path: &str) -> Citations {
+        let contents =
+            fs::read_to_string(citations_path).expect("Failed to read citations file");
+        if citations_path.ends_with(".json") {
+            serde_json::from_str(&contents).expect("Failed to parse JSON")
+        } else if citations_path.ends_with(".yaml") || citations_path.ends_with(".yml") {
+            serde_yaml::from_str(&contents).expect("Failed to parse YAML")
+        } else {
+            panic!("Citations file must be in YAML or JSON format")
+        }
+    }
+}
+
+pub type Citations = Vec<Citation>;
 
 /// A vector of Citation objects.
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/csln/src/lib.rs
+++ b/csln/src/lib.rs
@@ -5,3 +5,7 @@ pub mod bibliography;
 pub use bibliography::InputBibliography;
 
 pub mod citation;
+
+pub trait HasFile {
+    fn from_file(path: &str) -> Self;
+}

--- a/processor/benches/proc_bench.rs
+++ b/processor/benches/proc_bench.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use csln::bibliography::HasFile;
 use csln::bibliography::InputBibliography as Bibliography;
 use csln::citation::Citation;
 use csln::style::Style;
+use csln::HasFile;
 use csln_processor::Processor;
 use std::time::Duration;
 

--- a/processor/examples/citation.yaml
+++ b/processor/examples/citation.yaml
@@ -1,13 +1,13 @@
 ---
 - mode: non-integral
-  references:
+  citation_items:
     - refId: "doe1"
     - refId: "doe2"
 - mode: integral
-  references:
+  citation_items:
     - refId: "doe2"
       suffix: ["page 42"]
 - mode: non-integral
   prefix: "see "
-  references:
+  citation_items:
     - refId: "doe3"

--- a/processor/examples/citation.yaml
+++ b/processor/examples/citation.yaml
@@ -1,4 +1,8 @@
 ---
+- mode: non-integral
+  references:
+    - refId: "doe1"
+    - refId: "doe2"
 - mode: integral
   references:
     - refId: "doe2"

--- a/processor/examples/style.csl.yaml
+++ b/processor/examples/style.csl.yaml
@@ -36,6 +36,8 @@ citation:
   template:
     - contributor: author
       form: short
+    - date: issued
+      form: year
 bibliography: 
   template:
     - contributor: author

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -644,7 +644,7 @@ impl Processor {
         ProcReferences { bibliography, citations }
     }
 
-    fn process_citations(&self, citations: &[Citation]) -> ProcCitations {
+    fn process_citations(&self, citations: &Citations) -> ProcCitations {
         citations
             .iter()
             .map(|citation| self.process_citation(citation))
@@ -652,7 +652,6 @@ impl Processor {
     }
 
     fn process_citation(&self, citation: &Citation) -> ProcCitation {
-        // map citation_items to a ProcCitation
         citation
             .citation_items
             .iter()
@@ -660,7 +659,7 @@ impl Processor {
             .collect()
     }
 
-    fn process_citation_item(
+    pub fn process_citation_item(
         &self,
         citation_item: &CitationItem,
     ) -> Option<ProcCitationItem> {
@@ -677,6 +676,7 @@ impl Processor {
         reference: &InputReference,
     ) -> Vec<ProcTemplateComponent> {
         let bibliography_style = self.style.bibliography.clone();
+        // TODO bibliography should probably be Optional
         self.process_template(reference, bibliography_style.unwrap().template.as_slice())
     }
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -449,6 +449,7 @@ impl ComponentValues for TemplateContributor {
                             role_form,
                             editor_length,
                         )
+                        // FIXME
                         .unwrap()
                     });
                     let suffix_padded = suffix.and_then(|s| {
@@ -739,7 +740,7 @@ impl Processor {
         self.citations
             .iter()
             .flat_map(|c| {
-                c.references
+                c.citation_items
                     .iter()
                     .map(|cr| cr.ref_id.clone())
                     .collect::<Vec<String>>()

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -6,7 +6,7 @@ SPDX-FileCopyrightText: © 2023 Bruce D'Arcus
 use csln::bibliography::reference::InputReference;
 use csln::bibliography::reference::{EdtfString, RefID};
 use csln::bibliography::InputBibliography as Bibliography;
-use csln::citation::Citation;
+use csln::citation::{Citation, CitationItem};
 use csln::style::locale::Locale;
 use csln::style::options::{Config, MonthFormat, SortKey, SubstituteKey};
 use csln::style::template::{
@@ -619,15 +619,55 @@ impl ComponentValues for TemplateDate {
 //     assert_eq!(rendered_date, "2020");
 // }
 
+/// The intermediate representation of renderered citations and bibliography..
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+pub struct ProcReferences {
+    pub bibliography: Vec<ProcTemplate>,
+    pub citations: Option<Vec<ProcTemplate>>,
+}
+
 impl Processor {
     /// Render references to AST.
     #[inline]
-    pub fn process_references(&self) -> Vec<ProcTemplate> {
+    pub fn process_references(&self) -> ProcReferences {
         let sorted_references = self.sort_references(self.get_references());
-        sorted_references
+        let bibliography = sorted_references
             .par_iter()
             .map(|reference| self.process_reference(reference))
+            .collect();
+        let citations = self.process_citations(&self.citations);
+        ProcReferences { bibliography, citations: Some(citations) }
+    }
+
+    fn process_citations(
+        &self,
+        citations: &[Citation],
+    ) -> Vec<Vec<ProcTemplateComponent>> {
+        citations
+            .iter()
+            .map(|citation| self.process_citation(citation))
             .collect()
+    }
+
+    fn process_citation(&self, citation: &Citation) -> Vec<ProcTemplateComponent> {
+        // map the citation items to a vector of ProcTemplateComponents
+        citation
+            .citation_items
+            .iter()
+            .filter_map(|citation_item| self.process_citation_item(citation_item))
+            .flatten() // Flatten the nested vectors
+            .collect()
+    }
+
+    fn process_citation_item(
+        &self,
+        citation_item: &CitationItem,
+    ) -> Option<Vec<ProcTemplateComponent>> {
+        let citation_style = self.style.citation.clone();
+        let reference = self.get_reference(&citation_item.ref_id)?;
+        let proc_template =
+            self.process_template(&reference, citation_style?.template.as_slice());
+        Some(proc_template)
     }
 
     /// Render a reference to AST.

--- a/processor/tests/processor_test.rs
+++ b/processor/tests/processor_test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
-    use csln::bibliography::HasFile;
     use csln::citation::Citation;
+    use csln::HasFile;
     // create tests for Processor::get_proc_references and Processor::sort_proc_references
     #[test]
     fn sorts_references() {


### PR DESCRIPTION
It seems right to add this key piece of functionality next.

I will likely only add author-date initially, since that's all I really use myself. But if so, I will design it all along the same lines as 1.0.

Also, I will initially only support a more abstract import format; not actual documents. Still waiting on djot support for citations.

I thought I had this working, but it turns out not; `process_citations` is currently returning empty vectors.

```js
  "citations": [
    [],
    [],
    []
  ]
```

Digging a bit more, I think I may need to rethink and refactor the rendering code to account for the citations.

----------------

## Details

I'm not sure how best to do this, but probably need to look at https://github.com/jgm/citeproc and  https://github.com/zotero/citeproc-rs, though I have a hard time understanding the code in many places. 

This could be the citation definition, but doesn't seem right.

https://github.com/zotero/citeproc-rs/blob/2ab195a1e6f84f0ff284813ece61dc62096abbfe/crates/pandoc-types/src/definition.rs#L222

See, though, the [design document](https://github.com/zotero/citeproc-rs/blob/master/docs/design.md). It takes a parallel approach, where in "Pass 1", it creates different representations of the intermediate output, that can be resolved in "Pass 2."

## haskell citeproc

Here's the haskell processor type, which makes more sense to me.

https://github.com/jgm/citeproc/blob/6969ce218d0dfdee29d54cce674c7f9cef4b4f0a/src/Citeproc/Types.hs#L310
https://github.com/jgm/citeproc/blob/6969ce218d0dfdee29d54cce674c7f9cef4b4f0a/src/Citeproc/Types.hs#L263

```haskell
data Citation a =
  Citation { citationId         :: Maybe Text
           , citationNoteNumber :: Maybe Int
           , citationItems      :: [CitationItem a] }

data CitationItem a =
  CitationItem
  { citationItemId             :: ItemId
  , citationItemLabel          :: Maybe Text
  , citationItemLocator        :: Maybe Text
  , citationItemType           :: CitationItemType
  , citationItemPrefix         :: Maybe a
  , citationItemSuffix         :: Maybe a
  , citationItemData           :: Maybe (Reference a)
  }

data CitationItemType =
    AuthorOnly      -- ^ e.g., Smith
  | SuppressAuthor  -- ^ e.g., (2000, p. 30)
  | NormalCite      -- ^ e.g., (Smith 2000, p. 30)
```

Here's the high-level processing logic, which is basically what I am planning here.

https://github.com/jgm/citeproc/blob/6969ce218d0dfdee29d54cce674c7f9cef4b4f0a/src/Citeproc.hs#L20C23-L20C23

```haskell
-- | Process a list of 'Citation's, producing formatted citations
-- and a bibliography according to the rules of a CSL 'Style'.
-- If a 'Lang' is specified, override the style's default locale.
-- To obtain a 'Style' from an XML stylesheet, use
-- 'parseStyle' from "Citeproc.Style".
citeproc :: CiteprocOutput a
         => CiteprocOptions    -- ^ Rendering options
         -> Style a            -- ^ Parsed CSL style
         -> Maybe Lang         -- ^ Overrides default locale for style
         -> [Reference a]      -- ^ List of references (bibliographic data)
         -> [Citation a]       -- ^ List of citations to process
         -> Result a
```

Question: how are rendered citations inserted in document?

## Disambiguation

... I also need to figure out where and how disambiguation fits in this.

https://github.com/jgm/citeproc/blob/6969ce218d0dfdee29d54cce674c7f9cef4b4f0a/src/Citeproc/Eval.hs#L408

I'm hoping other aspects of this design will make this part easier, but I haven't yet figured it out.

My initial thoughts:

The main aspects of disambiguation I need to focus on first are (author) names, and years.

The latter is easy because in practice it's global. So I've already implemented it.

The former is the tricky piece, since typically it applies to citations, and not bibliographies (I guess unless a style requires a given name initial to be expanded?).

I suppose one option would be to follow the citeproc-rs approach: somehow generate alternate name representations on first pass, and disambiguate them separately.

Maybe I could create a hash-table for author names, something vaguely like:

```rust
pub struct Author {
    pub name: String,
    pub disambiguate_given: Vec<String>,
    pub role: ContributorRole,
    pub substitute: bool,
}
```

Regardless of the details, the idea would be to lookup the right name with disambiguation string in that hash map.